### PR TITLE
Add support to load all Responders in an Assembly.

### DIFF
--- a/Backend/Remora.Discord.Gateway/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/Remora.Discord.Gateway/Extensions/ServiceCollectionExtensions.cs
@@ -80,31 +80,6 @@ namespace Remora.Discord.Gateway.Extensions
         }
 
         /// <summary>
-        /// Adds all exported responders in the provided assembly to the service collection.
-        /// This method registers the responder as being available for all <see cref="IResponder{T}"/>
-        /// implementations it supports.
-        /// </summary>
-        /// <param name="serviceCollection">The service collection.</param>
-        /// <param name="assembly">The assembly to search.</param>
-        /// <returns>The service collection, with the responder added.</returns>
-        public static IServiceCollection AddRespondersFromAssembly
-        (
-            this IServiceCollection serviceCollection,
-            Assembly assembly
-        )
-        {
-            var types = assembly.GetExportedTypes()
-                .Where(t => t.IsResponder());
-
-            foreach (var type in types)
-            {
-                serviceCollection.AddResponder(type);
-            }
-
-            return serviceCollection;
-        }
-
-        /// <summary>
         /// Adds a responder to the service collection. This method registers the responder as being available for all
         /// <see cref="IResponder{T}"/> implementations it supports.
         /// </summary>

--- a/Backend/Remora.Discord.Gateway/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/Remora.Discord.Gateway/Extensions/ServiceCollectionExtensions.cs
@@ -93,9 +93,8 @@ namespace Remora.Discord.Gateway.Extensions
             Assembly assembly
         )
         {
-            // ReSharper disable once SuspiciousTypeConversion.Global
             var types = assembly.GetExportedTypes()
-                .Where(t => t is IResponder);
+                .Where(t => t.IsResponder());
 
             foreach (var type in types)
             {
@@ -115,8 +114,7 @@ namespace Remora.Discord.Gateway.Extensions
         /// <exception cref="ArgumentException">Throws if responderType does not implement <see cref="IResponder"/>.</exception>
         public static IServiceCollection AddResponder(this IServiceCollection serviceCollection, Type responderType)
         {
-            // ReSharper disable once SuspiciousTypeConversion.Global
-            if (!(responderType is IResponder))
+            if (!responderType.IsResponder())
             {
                 throw new ArgumentException(
                     $"{nameof(responderType)} should implement {nameof(IResponder)}.",

--- a/Backend/Remora.Discord.Gateway/Extensions/TypeExtensions.cs
+++ b/Backend/Remora.Discord.Gateway/Extensions/TypeExtensions.cs
@@ -40,7 +40,7 @@ namespace Remora.Discord.Gateway.Extensions
         {
             var interfaces = type.GetInterfaces();
             return interfaces.Any(
-                i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IResponder)
+                i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IResponder<>)
             );
         }
     }

--- a/Backend/Remora.Discord.Gateway/Extensions/TypeExtensions.cs
+++ b/Backend/Remora.Discord.Gateway/Extensions/TypeExtensions.cs
@@ -36,7 +36,7 @@ namespace Remora.Discord.Gateway.Extensions
         /// </summary>
         /// <param name="type">The <see cref="Type"/> to check against.</param>
         /// <returns>True if the type implements <see cref="IResponder{T}"/>.</returns>
-        internal static bool IsResponder(this Type type)
+        public static bool IsResponder(this Type type)
         {
             var interfaces = type.GetInterfaces();
             return interfaces.Any(

--- a/Backend/Remora.Discord.Gateway/Extensions/TypeExtensions.cs
+++ b/Backend/Remora.Discord.Gateway/Extensions/TypeExtensions.cs
@@ -1,0 +1,47 @@
+//
+//  TypeExtensions.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Linq;
+using Remora.Discord.Gateway.Responders;
+
+namespace Remora.Discord.Gateway.Extensions
+{
+    /// <summary>
+    /// Defines extension methods for the <see cref="Type"/> class.
+    /// </summary>
+    public static class TypeExtensions
+    {
+        /// <summary>
+        /// Checks if the <see cref="Type"/> implements <see cref="IResponder{T}"/>.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> to check against.</param>
+        /// <returns>True if the type implements <see cref="IResponder{T}"/>.</returns>
+        internal static bool IsResponder(this Type type)
+        {
+            var interfaces = type.GetInterfaces();
+            return interfaces.Any(
+                i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IResponder)
+            );
+        }
+    }
+}

--- a/Backend/Remora.Discord.Gateway/Services/ResponderService.cs
+++ b/Backend/Remora.Discord.Gateway/Services/ResponderService.cs
@@ -25,6 +25,7 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Gateway.Events;
+using Remora.Discord.Gateway.Extensions;
 using Remora.Discord.Gateway.Responders;
 
 namespace Remora.Discord.Gateway.Services
@@ -52,8 +53,7 @@ namespace Remora.Discord.Gateway.Services
         /// <param name="responderType">The responder type.</param>
         internal void RegisterResponderType(Type responderType)
         {
-            // ReSharper disable once SuspiciousTypeConversion.Global
-            if (!(responderType is IResponder))
+            if (!responderType.IsResponder())
             {
                 throw new ArgumentException(
                     $"{nameof(responderType)} should implement {nameof(IResponder)}.",

--- a/Backend/Remora.Discord.Gateway/Services/ResponderService.cs
+++ b/Backend/Remora.Discord.Gateway/Services/ResponderService.cs
@@ -43,7 +43,24 @@ namespace Remora.Discord.Gateway.Services
         /// <typeparam name="TResponder">The responder type.</typeparam>
         internal void RegisterResponderType<TResponder>() where TResponder : IResponder
         {
-            var responderTypeInterfaces = typeof(TResponder).GetInterfaces();
+            RegisterResponderType(typeof(TResponder));
+        }
+
+        /// <summary>
+        /// Adds a responder to the service.
+        /// </summary>
+        /// <param name="responderType">The responder type.</param>
+        internal void RegisterResponderType(Type responderType)
+        {
+            // ReSharper disable once SuspiciousTypeConversion.Global
+            if (!(responderType is IResponder))
+            {
+                throw new ArgumentException(
+                    $"{nameof(responderType)} should implement {nameof(IResponder)}.",
+                    nameof(responderType));
+            }
+
+            var responderTypeInterfaces = responderType.GetInterfaces();
             var responderInterfaces = responderTypeInterfaces.Where
             (
                 r => r.IsGenericType && r.GetGenericTypeDefinition() == typeof(IResponder<>)
@@ -57,12 +74,12 @@ namespace Remora.Discord.Gateway.Services
                     _registeredResponderTypes.Add(responderInterface, responderTypeList);
                 }
 
-                if (responderTypeList.Contains(typeof(TResponder)))
+                if (responderTypeList.Contains(responderType))
                 {
                     continue;
                 }
 
-                responderTypeList.Add(typeof(TResponder));
+                responderTypeList.Add(responderType);
             }
         }
 

--- a/Remora.Discord.sln
+++ b/Remora.Discord.sln
@@ -64,6 +64,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Remora.Discord.Unstable", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Remora.Discord.Commands", "Remora.Discord.Commands\Remora.Discord.Commands.csproj", "{B443C36D-5328-4031-818C-15FE47552E84}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LoadResolversFromAssembly", "Samples\LoadResolversFromAssembly\LoadResolversFromAssembly.csproj", "{DBC5EC20-B1A9-44F9-BC32-BC3A21551D87}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -130,6 +132,10 @@ Global
 		{B443C36D-5328-4031-818C-15FE47552E84}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B443C36D-5328-4031-818C-15FE47552E84}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B443C36D-5328-4031-818C-15FE47552E84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DBC5EC20-B1A9-44F9-BC32-BC3A21551D87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DBC5EC20-B1A9-44F9-BC32-BC3A21551D87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DBC5EC20-B1A9-44F9-BC32-BC3A21551D87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DBC5EC20-B1A9-44F9-BC32-BC3A21551D87}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{DC82899D-871E-4DC9-B61C-7619111800DE} = {26E93608-29BA-45C7-993A-AA24A49D6013}
@@ -147,5 +153,6 @@ Global
 		{C7FD32A5-C7A7-4F7E-9C96-C161780D08D6} = {6E2D59EB-648D-4968-8A63-8D8E3813EC86}
 		{2DAC9E24-AB35-45E3-9C5B-5CE3DA4E4FE5} = {26E93608-29BA-45C7-993A-AA24A49D6013}
 		{E9719E7E-B783-411D-8022-DC3BFD1D9534} = {6E2D59EB-648D-4968-8A63-8D8E3813EC86}
+		{DBC5EC20-B1A9-44F9-BC32-BC3A21551D87} = {D1A34922-E02F-492B-AEF5-9B34E81CE293}
 	EndGlobalSection
 EndGlobal

--- a/Samples/LoadResolversFromAssembly/LoadResolversFromAssembly.csproj
+++ b/Samples/LoadResolversFromAssembly/LoadResolversFromAssembly.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <OutputType>Exe</OutputType>
+        <RootNamespace>Remora.Discord.Samples.LoadResolversFromAssembly</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.9" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Backend\Remora.Discord.Gateway\Remora.Discord.Gateway.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Samples/LoadResolversFromAssembly/Program.cs
+++ b/Samples/LoadResolversFromAssembly/Program.cs
@@ -1,0 +1,107 @@
+//
+//  Program.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Remora.Discord.Gateway;
+using Remora.Discord.Gateway.Extensions;
+
+namespace Remora.Discord.Samples.LoadResolversFromAssembly
+{
+    /// <summary>
+    /// Represents the main class of the program.
+    /// </summary>
+    public class Program
+    {
+         /// <summary>
+        /// The main entrypoint of the program.
+        /// </summary>
+        /// <param name="args">The command-line arguments.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous program execution.</returns>
+        public static async Task Main(string[] args)
+        {
+            var cancellationSource = new CancellationTokenSource();
+
+            Console.CancelKeyPress += (sender, eventArgs) =>
+            {
+                eventArgs.Cancel = true;
+                cancellationSource.Cancel();
+            };
+
+            var botToken =
+                Environment.GetEnvironmentVariable("REMORA_BOT_TOKEN")
+                ?? throw new InvalidOperationException
+                (
+                    "No bot token has been provided. Set the REMORA_BOT_TOKEN environment variable to a valid token."
+                );
+
+            var serviceCollection = new ServiceCollection()
+                .AddLogging
+                (
+                    c => c
+                        .AddConsole()
+                        .AddFilter("System.Net.Http.HttpClient.*.LogicalHandler", LogLevel.Warning)
+                        .AddFilter("System.Net.Http.HttpClient.*.ClientHandler", LogLevel.Warning)
+                )
+                .AddDiscordGateway(() => botToken);
+
+            serviceCollection.AddHttpClient();
+
+            var responderTypes = typeof(Program).Assembly
+                .GetExportedTypes()
+                .Where(t => t.IsResponder());
+
+            foreach (var responderType in responderTypes)
+            {
+                serviceCollection.AddResponder(responderType);
+            }
+
+            var services = serviceCollection.BuildServiceProvider();
+
+            var log = services.GetRequiredService<ILogger<Program>>();
+
+            var gatewayClient = services.GetRequiredService<DiscordGatewayClient>();
+
+            var runResult = await gatewayClient.RunAsync(cancellationSource.Token);
+            if (!runResult.IsSuccess)
+            {
+                log.LogError(runResult.Exception, runResult.ErrorReason);
+
+                if (runResult.GatewayCloseStatus.HasValue)
+                {
+                    log.LogError($"Gateway close status: {runResult.GatewayCloseStatus}");
+                }
+
+                if (runResult.WebSocketCloseStatus.HasValue)
+                {
+                    log.LogError($"Websocket close status: {runResult.WebSocketCloseStatus}");
+                }
+            }
+
+            log.LogInformation("Bye bye");
+        }
+    }
+}

--- a/Samples/LoadResolversFromAssembly/Responders/EchoResponder.cs
+++ b/Samples/LoadResolversFromAssembly/Responders/EchoResponder.cs
@@ -1,0 +1,68 @@
+//
+//  EchoResponder.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Threading;
+using System.Threading.Tasks;
+using Remora.Discord.API.Abstractions.Gateway.Events;
+using Remora.Discord.API.Abstractions.Rest;
+using Remora.Discord.Gateway.Responders;
+using Remora.Discord.Gateway.Results;
+
+namespace Remora.Discord.Samples.LoadResolversFromAssembly.Responders
+{
+    /// <summary>
+    /// A Responder that sends all messages received back to where they were received.
+    /// </summary>
+    public class EchoResponder : IResponder<IMessageCreate>
+    {
+        private readonly IDiscordRestChannelAPI _channelAPI;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EchoResponder"/> class.
+        /// </summary>
+        /// <param name="channelAPI">The <see cref="IDiscordRestChannelAPI"/>.</param>
+        public EchoResponder(
+            IDiscordRestChannelAPI channelAPI)
+        {
+            _channelAPI = channelAPI;
+        }
+
+        /// <inheritdoc />
+        public async Task<EventResponseResult> RespondAsync(IMessageCreate gatewayEvent, CancellationToken ct = default)
+        {
+            if ((gatewayEvent.Author.IsBot.HasValue && gatewayEvent.Author.IsBot.Value) ||
+                (gatewayEvent.Author.IsSystem.HasValue && gatewayEvent.Author.IsSystem.Value))
+            {
+                return EventResponseResult.FromSuccess();
+            }
+
+            var replyResult = await this._channelAPI.CreateMessageAsync(
+                gatewayEvent.ChannelID,
+                gatewayEvent.Content,
+                ct: ct);
+
+            return replyResult.IsSuccess
+                ? EventResponseResult.FromSuccess()
+                : EventResponseResult.FromError(replyResult);
+        }
+    }
+}

--- a/Tests/Remora.Discord.Gateway.Tests/Responders/MockedResponder.cs
+++ b/Tests/Remora.Discord.Gateway.Tests/Responders/MockedResponder.cs
@@ -1,0 +1,42 @@
+//
+//  MockedResponder.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Threading;
+using System.Threading.Tasks;
+using Remora.Discord.API.Abstractions.Gateway.Events;
+using Remora.Discord.Gateway.Responders;
+using Remora.Discord.Gateway.Results;
+
+namespace Remora.Discord.Gateway.Tests.Responders
+{
+    /// <summary>
+    /// Represents a mocked <see cref="IResponder{T}"/>.
+    /// </summary>
+    public class MockedResponder : IResponder<IMessageCreate>
+    {
+        /// <inheritdoc />
+        public Task<EventResponseResult> RespondAsync(IMessageCreate gatewayEvent, CancellationToken ct = default)
+        {
+            return Task.FromResult(EventResponseResult.FromSuccess());
+        }
+    }
+}

--- a/Tests/Remora.Discord.Gateway.Tests/Tests/TypeExtensionsTests.cs
+++ b/Tests/Remora.Discord.Gateway.Tests/Tests/TypeExtensionsTests.cs
@@ -1,0 +1,46 @@
+//
+//  TypeExtensionsTests.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using Remora.Discord.Gateway.Extensions;
+using Remora.Discord.Gateway.Tests.Responders;
+using Xunit;
+
+namespace Remora.Discord.Gateway.Tests.Tests
+{
+    /// <summary>
+    /// Tests for the <see cref="TypeExtensions"/> class.
+    /// </summary>
+    public class TypeExtensionsTests
+    {
+        /// <summary>
+        /// Tests whether the return result from IsResponders is correct.
+        /// </summary>
+        [Fact]
+        public void DoesIsResponderReturnTrue()
+        {
+            var mockedResponderType = typeof(MockedResponder);
+            var doesImplementResponder = mockedResponderType.IsResponder();
+
+            Assert.True(doesImplementResponder);
+        }
+    }
+}

--- a/Tests/Remora.Discord.Gateway.Tests/Tests/TypeExtensionsTests.cs
+++ b/Tests/Remora.Discord.Gateway.Tests/Tests/TypeExtensionsTests.cs
@@ -32,15 +32,33 @@ namespace Remora.Discord.Gateway.Tests.Tests
     public class TypeExtensionsTests
     {
         /// <summary>
-        /// Tests whether the return result from IsResponders is correct.
+        /// Tests for the IResponder method in <see cref="TypeExtensions"/> class.
         /// </summary>
-        [Fact]
-        public void DoesIsResponderReturnTrue()
+        public class IsResponder
         {
-            var mockedResponderType = typeof(MockedResponder);
-            var doesImplementResponder = mockedResponderType.IsResponder();
+            /// <summary>
+            /// Tests whether a type implementing IResponder returns true.
+            /// </summary>
+            [Fact]
+            public void ReturnsTrueForTypeImplementingIResponder()
+            {
+                var type = typeof(MockedResponder);
+                var doesImplementResponder = type.IsResponder();
 
-            Assert.True(doesImplementResponder);
+                Assert.True(doesImplementResponder);
+            }
+
+            /// <summary>
+            /// Tests whether a type not implementing IResponder returns true.
+            /// </summary>
+            [Fact]
+            public void ReturnsFalseForTypeImplementingIResponder()
+            {
+                var type = typeof(string);
+                var doesImplementResponder = type.IsResponder();
+
+                Assert.False(doesImplementResponder);
+            }
         }
     }
 }


### PR DESCRIPTION
The objective of this PR is to add a user friendly way to load all types implementing `IResponder<T>` in an assembly. With the current implementation, it is not possible to do that, since `ResponderService.RegisterResponder<TResponder>()` is not only internal but does not provide a non-generic overload.