### PR TITLE
Fix exception on multiple command options

### DIFF
--- a/Remora.Discord.Commands/Responders/InteractionResponder.cs
+++ b/Remora.Discord.Commands/Responders/InteractionResponder.cs
@@ -163,8 +163,7 @@ namespace Remora.Discord.Commands.Responders
             commandStringBuilder ??= new StringBuilder();
             parameters ??= new Dictionary<string, IReadOnlyList<string>>();
 
-            var singleOption = options.SingleOrDefault();
-            if (singleOption is null)
+            if (options.Count > 1)
             {
                 // multiple parameters
                 foreach (var option in options)
@@ -174,6 +173,7 @@ namespace Remora.Discord.Commands.Responders
             }
             else
             {
+                var singleOption = options.Single();
                 if (singleOption.Value.HasValue)
                 {
                     // A single parameter

--- a/Remora.Discord.Commands/Responders/InteractionResponder.cs
+++ b/Remora.Discord.Commands/Responders/InteractionResponder.cs
@@ -171,7 +171,7 @@ namespace Remora.Discord.Commands.Responders
                     UnpackInteractionParameter(parameters, option);
                 }
             }
-            else
+            else if (options.Count == 1)
             {
                 var singleOption = options.Single();
                 if (singleOption.Value.HasValue)


### PR DESCRIPTION
Fixes an exception when using multiple options on a slash command. `SingleOrDefault` throws an exception when theres multiple options so the logic here was slightly wrong.