### PR TITLE
Fixed misuse of `TaskCreationOptions.LongRunning`

### DIFF
--- a/Backend/Remora.Discord.Gateway/DiscordGatewayClient.cs
+++ b/Backend/Remora.Discord.Gateway/DiscordGatewayClient.cs
@@ -423,11 +423,7 @@ namespace Remora.Discord.Gateway
                     // Set up the send task
                     var heartbeatInterval = hello.Data.HeartbeatInterval;
 
-                    _sendTask = Task.Factory.StartNew
-                    (
-                        () => GatewaySenderAsync(heartbeatInterval, _tokenSource.Token),
-                        TaskCreationOptions.LongRunning
-                    ).Unwrap();
+                    _sendTask = Task.Run(() => GatewaySenderAsync(heartbeatInterval, _tokenSource.Token));
 
                     // Attempt to connect or resume
                     var connectResult = await AttemptConnectionAsync(ct);
@@ -437,11 +433,7 @@ namespace Remora.Discord.Gateway
                     }
 
                     // Now, set up the receive task and start receiving events normally
-                    _receiveTask = Task.Factory.StartNew
-                    (
-                        () => GatewayReceiverAsync(_tokenSource.Token),
-                        TaskCreationOptions.LongRunning
-                    ).Unwrap();
+                    _receiveTask = Task.Run(() => GatewayReceiverAsync(_tokenSource.Token));
 
                     _log.LogInformation("Connected");
 


### PR DESCRIPTION
Long story short, `TaskCreationOptions.LongRunning` is for synchronous CPU-bound work, and this here is neither synchronous, nor CPU-bound.

Referring to the docs, this basically tells the thread pool to create an extra thread, to make up for the one that that this task is going to block for a long time.

```
Specifies that a task will be a long-running, coarse-grained operation involving fewer, larger components than fine-grained systems. It provides a hint to the TaskScheduler that oversubscription may be warranted. Oversubscription lets you create more threads than the available number of hardware threads. It also provides a hint to the task scheduler that an additional thread might be required for the task so that it does not block the forward progress of other threads or work items on the local thread-pool queue.
```

Except async methods (when done correctly, like these are) don't block the thread.

Furthermore, I would say that the `Task.Run()` call is also superfluous. The only difference between wrapping the send and listen calls in `Task.Run()` is that with `Task.Run()` they start in the background, at a later point. Calling them directly would have them start in the foreground, immediately, and then marshal to the background upon the first `await`.