### PR TITLE
Fixed that IHello events are not dispatched to responders. Fixes #36

### DIFF
--- a/Backend/Remora.Discord.Gateway/DiscordGatewayClient.cs
+++ b/Backend/Remora.Discord.Gateway/DiscordGatewayClient.cs
@@ -420,6 +420,8 @@ namespace Remora.Discord.Gateway
                         );
                     }
 
+                    UnwrapAndDispatchEvent(receiveHello.Entity, _tokenSource.Token);
+
                     // Set up the send task
                     var heartbeatInterval = hello.Data.HeartbeatInterval;
 


### PR DESCRIPTION
Alternatively, make `IHello` an `internal` type, and expose the `HeartbeatLifetime` value on the gateway client itself.