### PR TITLE
Reworked `IPayload<T>` to not allow for null data fields

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Gateway/IPayloadOfT.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Gateway/IPayloadOfT.cs
@@ -36,6 +36,6 @@ namespace Remora.Discord.API.Abstractions.Gateway
         /// <summary>
         /// Gets the data contained in the payload.
         /// </summary>
-        TData? Data { get; }
+        TData Data { get; }
     }
 }

--- a/Backend/Remora.Discord.API/API/Payload.cs
+++ b/Backend/Remora.Discord.API/API/Payload.cs
@@ -32,5 +32,5 @@ namespace Remora.Discord.API
     /// </summary>
     /// <typeparam name="TData">The data type encapsulated in the payload.</typeparam>
     [PublicAPI]
-    public record Payload<TData>(TData? Data) : IPayload<TData> where TData : IGatewayPayloadData;
+    public record Payload<TData>(TData Data) : IPayload<TData> where TData : IGatewayPayloadData;
 }

--- a/Backend/Remora.Discord.Gateway/Responders/IResponder.cs
+++ b/Backend/Remora.Discord.Gateway/Responders/IResponder.cs
@@ -53,6 +53,6 @@ namespace Remora.Discord.Gateway.Responders
         /// <param name="gatewayEvent">The event to respond to.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A response result which may or may not have succeeded.</returns>
-        Task<EventResponseResult> RespondAsync(TGatewayEvent? gatewayEvent, CancellationToken ct = default);
+        Task<EventResponseResult> RespondAsync(TGatewayEvent gatewayEvent, CancellationToken ct = default);
     }
 }


### PR DESCRIPTION
This eliminates the need for responders to allow for nullable data fields when the vast majority of them can never be null.