### PR TITLE
Fixed a compilation error when running in VS 2019 Preview

### DIFF
--- a/Tests/Remora.Discord.Commands.Tests/Extensions/CommandTreeExtensionTests.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Extensions/CommandTreeExtensionTests.cs
@@ -361,7 +361,7 @@ namespace Remora.Discord.Commands.Tests.Extensions
                     Assert.True(requiredParameter.IsRequired.HasValue);
                     Assert.True(requiredParameter.IsRequired.Value);
 
-                    var optionalCommand = commands.First(c => c.Name == "optional");
+                    var optionalCommand = commands!.First(c => c.Name == "optional");
                     var optionalParameter = optionalCommand.Options.Value!.First();
                     if (optionalParameter.IsRequired.HasValue)
                     {


### PR DESCRIPTION
Fixed a bug regarding nullability annotations, when running with the latest preview version of `Microsoft.CodeAnalysis.NetAnalyzers`.

Basically, putting a null-check-override on something once is no longer sufficient to eliminate null-checks down the line, when extensions are used. In truth, a null-check-override was never intended to carry down the line to future uses, but it appeared this way because Roslyn would incorrectly mark values that have the . operator applied to them as not possibly null, not realizing that extension methods make it possible to invoke the . operator upon null.

https://github.com/dotnet/roslyn/issues/48605