### PR TITLE
Fixed gateway reconnection, in response to network exceptions.

### DIFF
--- a/Tests/Remora.Discord.Gateway.Tests/Transport/Events/SendExceptionEvent.cs
+++ b/Tests/Remora.Discord.Gateway.Tests/Transport/Events/SendExceptionEvent.cs
@@ -1,0 +1,49 @@
+﻿//
+//  SendExceptionEvent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+
+namespace Remora.Discord.Gateway.Tests.Transport.Events
+{
+    /// <summary>
+    /// Represents an exception occuring in server-to-client stream of the transport layer.
+    /// </summary>
+    public class SendExceptionEvent : IEvent
+    {
+        private readonly Func<Exception> _exceptionFactory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SendExceptionEvent"/> class.
+        /// </summary>
+        /// <param name="exceptionFactory">The exception factory function.</param>
+        public SendExceptionEvent(Func<Exception> exceptionFactory)
+        {
+            _exceptionFactory = exceptionFactory;
+        }
+
+        /// <summary>
+        /// Creates the exception that should be sent.
+        /// </summary>
+        /// <returns>The exception.</returns>
+        public Exception CreateException() => _exceptionFactory();
+    }
+}

--- a/Tests/Remora.Discord.Gateway.Tests/Transport/MockedTransportSequenceBuilder.cs
+++ b/Tests/Remora.Discord.Gateway.Tests/Transport/MockedTransportSequenceBuilder.cs
@@ -150,6 +150,17 @@ namespace Remora.Discord.Gateway.Tests.Transport
         }
 
         /// <summary>
+        /// Adds an instruction to throw an exception in the server-to-client transport stream.
+        /// </summary>
+        /// <param name="exceptionFactory">A factory function for the exception to be thrown.</param>
+        /// <returns>The action builder, with the exception.</returns>
+        public MockedTransportSequenceBuilder SendException(Func<Exception> exceptionFactory)
+        {
+            _sequence.Add(new SendExceptionEvent(exceptionFactory));
+            return this;
+        }
+
+        /// <summary>
         /// Builds the transport sequence.
         /// </summary>
         /// <returns>The transport sequence.</returns>


### PR DESCRIPTION
Fixed that the gateway client would not properly reconnect in the event of a network exception, due to improper management of cancellation tokens.

Resolves #39.