### PR TITLE
fix payload converter logic for empty payloads.

### DIFF
--- a/Backend/Remora.Discord.API/Json/Converters/Internal/PayloadConverter.cs
+++ b/Backend/Remora.Discord.API/Json/Converters/Internal/PayloadConverter.cs
@@ -269,7 +269,7 @@ namespace Remora.Discord.API.Json
         private static IPayload DeserializeEmptyPayload<TData>(JsonElement dataProperty)
             where TData : IGatewayPayloadData, new()
         {
-            if (dataProperty.ValueKind is not JsonValueKind.Undefined or JsonValueKind.Null)
+            if (dataProperty.ValueKind is not JsonValueKind.Undefined and not JsonValueKind.Null)
             {
                 throw new JsonException();
             }


### PR DESCRIPTION
The original converter logic here:

https://github.com/Nihlus/Remora.Discord/blob/1a430d69cfea203ecb46d64a24171be5846cfedc/Backend/Remora.Discord.API/Json/Converters/Internal/PayloadConverter.cs#L272-L274

actually translates into:

```csharp
dataProperty.ValueKind != JsonValueKind.Undefined || dataProperty.ValueKind == JsonValueKind.Null
```

which is not correct - we actually want to check if it is not undefined or is NOT null. This PR fixes that.

note: this could also be `dataProperty.ValueKind is not (JsonValueKind.Undefined or JsonValueKind.Null)` - either way works the same. There also is no unit test I could find for this - I would add my own but I see the repo has a very specific setup for tests so if you'd like me to add some, some internal guidance would be nice. Thanks!