### PR TITLE
JSON Sample Data Test Naming

### DIFF
--- a/Tests/Remora.Discord.API.Tests/Services/SampleBidirectionalDataSource.cs
+++ b/Tests/Remora.Discord.API.Tests/Services/SampleBidirectionalDataSource.cs
@@ -30,7 +30,7 @@ namespace Remora.Discord.API.Tests.Services
     /// Represents a source of sample data for an xUnit test.
     /// </summary>
     /// <typeparam name="TData">The data type.</typeparam>
-    public class SampleBidirectionalDataSource<TData> : TheoryData<string> where TData : IGatewayEvent, IGatewayCommand
+    public class SampleBidirectionalDataSource<TData> : TheoryData<SampleDataDescriptor> where TData : IGatewayEvent, IGatewayCommand
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SampleBidirectionalDataSource{TData}"/> class.

--- a/Tests/Remora.Discord.API.Tests/Services/SampleCommandDataSource.cs
+++ b/Tests/Remora.Discord.API.Tests/Services/SampleCommandDataSource.cs
@@ -29,7 +29,7 @@ namespace Remora.Discord.API.Tests.Services
     /// Represents a source of sample data for an xUnit test.
     /// </summary>
     /// <typeparam name="TData">The data type.</typeparam>
-    public class SampleCommandDataSource<TData> : TheoryData<string> where TData : IGatewayCommand
+    public class SampleCommandDataSource<TData> : TheoryData<SampleDataDescriptor> where TData : IGatewayCommand
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SampleCommandDataSource{TData}"/> class.

--- a/Tests/Remora.Discord.API.Tests/Services/SampleDataDescriptor.cs
+++ b/Tests/Remora.Discord.API.Tests/Services/SampleDataDescriptor.cs
@@ -1,0 +1,65 @@
+﻿//
+//  SampleDataDescriptor.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.IO;
+
+namespace Remora.Discord.API.Tests.Services
+{
+    /// <summary>
+    /// Describes a file containing sample data, for testing.
+    /// </summary>
+    public class SampleDataDescriptor
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SampleDataDescriptor"/> class.
+        /// </summary>
+        /// <param name="basePath">The value to use for <see cref="BasePath"/>.</param>
+        /// <param name="relativePath">The value to use for <see cref="RelativePath"/>.</param>
+        public SampleDataDescriptor(
+            string basePath,
+            string relativePath)
+        {
+            BasePath = basePath;
+            RelativePath = relativePath;
+        }
+
+        /// <summary>
+        /// Gets the base path at which the sample data file may be found.
+        /// </summary>
+        public string BasePath { get; }
+
+        /// <summary>
+        /// Gets the full filesystem path of the sample data file.
+        /// </summary>
+        public string FullPath
+            => Path.Combine(BasePath, RelativePath);
+
+        /// <summary>
+        /// Gets the path to the sample data file, relative to other sample data files.
+        /// </summary>
+        public string RelativePath { get; }
+
+        /// <inheritdoc/>
+        public override string? ToString()
+            => RelativePath;
+    }
+}

--- a/Tests/Remora.Discord.API.Tests/Services/SampleDataService.cs
+++ b/Tests/Remora.Discord.API.Tests/Services/SampleDataService.cs
@@ -41,7 +41,7 @@ namespace Remora.Discord.API.Tests.Services
         /// </summary>
         /// <typeparam name="TType">The API type.</typeparam>
         /// <returns>A retrieval result which may or may not have succeeded.</returns>
-        public RetrieveEntityResult<IReadOnlyList<string>> GetSampleEventDataSet<TType>()
+        public RetrieveEntityResult<IReadOnlyList<SampleDataDescriptor>> GetSampleEventDataSet<TType>()
             where TType : IGatewayEvent
             => GetSampleDataSet<TType>(Path.Combine("Gateway", "Events"));
 
@@ -50,7 +50,7 @@ namespace Remora.Discord.API.Tests.Services
         /// </summary>
         /// <typeparam name="TType">The API type.</typeparam>
         /// <returns>A retrieval result which may or may not have succeeded.</returns>
-        public RetrieveEntityResult<IReadOnlyList<string>> GetSampleCommandDataSet<TType>()
+        public RetrieveEntityResult<IReadOnlyList<SampleDataDescriptor>> GetSampleCommandDataSet<TType>()
             where TType : IGatewayCommand
             => GetSampleDataSet<TType>(Path.Combine("Gateway", "Commands"));
 
@@ -59,7 +59,7 @@ namespace Remora.Discord.API.Tests.Services
         /// </summary>
         /// <typeparam name="TType">The API type.</typeparam>
         /// <returns>A retrieval result which may or may not have succeeded.</returns>
-        public RetrieveEntityResult<IReadOnlyList<string>> GetSampleBidirectionalDataSet<TType>()
+        public RetrieveEntityResult<IReadOnlyList<SampleDataDescriptor>> GetSampleBidirectionalDataSet<TType>()
             where TType : IGatewayEvent, IGatewayCommand
             => GetSampleDataSet<TType>(Path.Combine("Gateway", "Bidirectional"));
 
@@ -68,7 +68,7 @@ namespace Remora.Discord.API.Tests.Services
         /// </summary>
         /// <typeparam name="TType">The API type.</typeparam>
         /// <returns>A retrieval result which may or may not have succeeded.</returns>
-        public RetrieveEntityResult<IReadOnlyList<string>> GetSampleObjectDataSet<TType>()
+        public RetrieveEntityResult<IReadOnlyList<SampleDataDescriptor>> GetSampleObjectDataSet<TType>()
             => GetSampleDataSet<TType>("Objects");
 
         private RetrieveEntityResult<string> GetBaseSampleDataPath()
@@ -82,12 +82,12 @@ namespace Remora.Discord.API.Tests.Services
             return Path.Combine(basePath, "Samples");
         }
 
-        private RetrieveEntityResult<IReadOnlyList<string>> GetSampleDataSet<TType>(string subfolder)
+        private RetrieveEntityResult<IReadOnlyList<SampleDataDescriptor>> GetSampleDataSet<TType>(string subfolder)
         {
             var getBasePath = GetBaseSampleDataPath();
             if (!getBasePath.IsSuccess)
             {
-                return RetrieveEntityResult<IReadOnlyList<string>>.FromError(getBasePath);
+                return RetrieveEntityResult<IReadOnlyList<SampleDataDescriptor>>.FromError(getBasePath);
             }
 
             var basePath = Path.Combine(getBasePath.Entity, subfolder);
@@ -101,10 +101,14 @@ namespace Remora.Discord.API.Tests.Services
             var samplesPath = Path.Combine(basePath, samplesDirectoryName);
             if (!Directory.Exists(samplesPath))
             {
-                return RetrieveEntityResult<IReadOnlyList<string>>.FromError("No valid sample data found.");
+                return RetrieveEntityResult<IReadOnlyList<SampleDataDescriptor>>.FromError("No valid sample data found.");
             }
 
-            return Directory.EnumerateFiles(samplesPath, "*.json", SearchOption.AllDirectories).ToList();
+            return Directory.EnumerateFiles(samplesPath, "*.json", SearchOption.AllDirectories)
+                .Select(fullPath => new SampleDataDescriptor(
+                    basePath,
+                    Path.GetRelativePath(basePath, fullPath)))
+                .ToArray();
         }
     }
 }

--- a/Tests/Remora.Discord.API.Tests/Services/SampleEventDataSource.cs
+++ b/Tests/Remora.Discord.API.Tests/Services/SampleEventDataSource.cs
@@ -29,7 +29,7 @@ namespace Remora.Discord.API.Tests.Services
     /// Represents a source of sample data for an xUnit test.
     /// </summary>
     /// <typeparam name="TData">The data type.</typeparam>
-    public class SampleEventDataSource<TData> : TheoryData<string> where TData : IGatewayEvent
+    public class SampleEventDataSource<TData> : TheoryData<SampleDataDescriptor> where TData : IGatewayEvent
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SampleEventDataSource{TData}"/> class.

--- a/Tests/Remora.Discord.API.Tests/Services/SampleObjectDataSource.cs
+++ b/Tests/Remora.Discord.API.Tests/Services/SampleObjectDataSource.cs
@@ -28,7 +28,7 @@ namespace Remora.Discord.API.Tests.Services
     /// Represents a source of sample data for an xUnit test.
     /// </summary>
     /// <typeparam name="TData">The data type.</typeparam>
-    public class SampleObjectDataSource<TData> : TheoryData<string>
+    public class SampleObjectDataSource<TData> : TheoryData<SampleDataDescriptor>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SampleObjectDataSource{TData}"/> class.

--- a/Tests/Remora.Discord.API.Tests/TestBases/GatewayTestBase.cs
+++ b/Tests/Remora.Discord.API.Tests/TestBases/GatewayTestBase.cs
@@ -24,6 +24,8 @@ using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Remora.Discord.API.Abstractions.Gateway;
+using Remora.Discord.API.Tests.Services;
+
 using Xunit;
 
 namespace Remora.Discord.API.Tests.TestBases
@@ -35,13 +37,13 @@ namespace Remora.Discord.API.Tests.TestBases
         /// <summary>
         /// Tests whether the type can be deserialized from a JSON object.
         /// </summary>
-        /// <param name="sampleDataPath">The sample data.</param>
+        /// <param name="sampleDataFile">The sample data.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [SkippableTheory]
         [MemberData(nameof(SampleSource), DisableDiscoveryEnumeration = true)]
-        public async Task DeserializedCorrectType(string sampleDataPath)
+        public async Task DeserializedCorrectType(SampleDataDescriptor sampleDataFile)
         {
-            await using var sampleData = File.OpenRead(sampleDataPath);
+            await using var sampleData = File.OpenRead(sampleDataFile.FullPath);
             var payload = await JsonSerializer.DeserializeAsync<IPayload>(sampleData, this.Options);
 
             Assert.IsAssignableFrom<IPayload<TType>>(payload);

--- a/Tests/Remora.Discord.API.Tests/TestBases/JsonBackedTypeTestBase.cs
+++ b/Tests/Remora.Discord.API.Tests/TestBases/JsonBackedTypeTestBase.cs
@@ -86,13 +86,13 @@ namespace Remora.Discord.API.Tests.TestBases
         /// <summary>
         /// Tests whether the type can be deserialized from a JSON object.
         /// </summary>
-        /// <param name="sampleDataPath">The sample data.</param>
+        /// <param name="sampleDataFile">The sample data.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [SkippableTheory]
         [MemberData(nameof(SampleSource), DisableDiscoveryEnumeration = true)]
-        public async Task CanDeserialize(string sampleDataPath)
+        public async Task CanDeserialize(SampleDataDescriptor sampleDataFile)
         {
-            await using var sampleData = File.OpenRead(sampleDataPath);
+            await using var sampleData = File.OpenRead(sampleDataFile.FullPath);
             var payload = await JsonSerializer.DeserializeAsync<TType>(sampleData, this.Options);
             Assert.NotNull(payload);
         }
@@ -100,13 +100,13 @@ namespace Remora.Discord.API.Tests.TestBases
         /// <summary>
         /// Tests whether the type can be serialized to a JSON object.
         /// </summary>
-        /// <param name="sampleDataPath">The sample data.</param>
+        /// <param name="sampleDataFile">The sample data.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [SkippableTheory]
         [MemberData(nameof(SampleSource), DisableDiscoveryEnumeration = true)]
-        public async Task CanSerialize(string sampleDataPath)
+        public async Task CanSerialize(SampleDataDescriptor sampleDataFile)
         {
-            await using var sampleData = File.OpenRead(sampleDataPath);
+            await using var sampleData = File.OpenRead(sampleDataFile.FullPath);
             var payload = await JsonSerializer.DeserializeAsync<TType>(sampleData, this.Options);
 
             Assert.NotNull(payload);
@@ -119,13 +119,13 @@ namespace Remora.Discord.API.Tests.TestBases
         /// Tests whether data survives being round-tripped by the type - that is, it can be deserialized and then
         /// serialized again without data loss.
         /// </summary>
-        /// <param name="sampleDataPath">The sample data.</param>
+        /// <param name="sampleDataFile">The sample data.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [SkippableTheory]
         [MemberData(nameof(SampleSource), DisableDiscoveryEnumeration = true)]
-        public async Task SurvivesRoundTrip(string sampleDataPath)
+        public async Task SurvivesRoundTrip(SampleDataDescriptor sampleDataFile)
         {
-            await using var sampleData = File.OpenRead(sampleDataPath);
+            await using var sampleData = File.OpenRead(sampleDataFile.FullPath);
             var deserialized = await JsonSerializer.DeserializeAsync<TType>(sampleData, this.Options);
 
             Assert.NotNull(deserialized);


### PR DESCRIPTION
Enhanced the JSON Sample Data testing system to display more meaingful test names, I.E. to have test names only include the relative path of the JSON file, not the full filesystem path, which would generally result in test names being truncated and unreadable within an IDE.