### PR TITLE
Remove trailing "?" when there are no query params

### DIFF
--- a/Backend/Remora.Discord.Rest/API/RestRequestBuilder.cs
+++ b/Backend/Remora.Discord.Rest/API/RestRequestBuilder.cs
@@ -211,7 +211,7 @@ namespace Remora.Discord.Rest.API
                 queryParameters.Add(queryName, queryValue);
             }
 
-            var request = new HttpRequestMessage(_method, _endpoint + "?" + queryParameters);
+            var request = new HttpRequestMessage(_method, _endpoint + (queryParameters.Count > 0 ? "?" + queryParameters : string.Empty));
 
             foreach (var (headerName, headerValue) in _additionalHeaders)
             {


### PR DESCRIPTION
Small change to remove the trailing question mark in query strings when there isn't actually a query. 

Unsure what the HTTP spec specifies in this case, but I don't feel it's semantically correct to leave it at the end when it's not being used. 