### PR TITLE
Enhanced bulk overwriting of slash command definitions

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/IApplicationCommandOverwriteData.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/IApplicationCommandOverwriteData.cs
@@ -1,0 +1,49 @@
+﻿//
+//  IApplicationCommandOverwriteData.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+
+using JetBrains.Annotations;
+
+using Remora.Discord.Core;
+
+namespace Remora.Discord.API.Abstractions.Objects
+{
+    /// <summary>
+    /// Represents a request to create or update an application command.
+    /// </summary>
+    [PublicAPI]
+    public interface IApplicationCommandOverwriteData
+    {
+        /// <inheritdoc cref="IApplicationCommand.Name"/>
+        string Name { get; }
+
+        /// <inheritdoc cref="IApplicationCommand.Description"/>
+        string Description { get; }
+
+        /// <inheritdoc cref="IApplicationCommand.Options"/>
+        Optional<IReadOnlyList<IApplicationCommandOption>> Options { get; }
+
+        /// <inheritdoc cref="IApplicationCommand.DefaultPermission"/>
+        Optional<bool> DefaultPermission { get; }
+    }
+}

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/IApplicationCommandOverwriteData.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/IApplicationCommandOverwriteData.cs
@@ -21,9 +21,7 @@
 //
 
 using System.Collections.Generic;
-
 using JetBrains.Annotations;
-
 using Remora.Discord.Core;
 
 namespace Remora.Discord.API.Abstractions.Objects

--- a/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestApplicationAPI.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestApplicationAPI.cs
@@ -81,10 +81,7 @@ namespace Remora.Discord.API.Abstractions.Rest
         Task<Result<IReadOnlyList<IApplicationCommand>>> BulkOverwriteGlobalApplicationCommandsAsync
         (
             Snowflake applicationID,
-            IReadOnlyList
-            <
-                (string Name, string Description, Optional<IReadOnlyList<IApplicationCommandOption>> Options)
-            > commands,
+            IReadOnlyList<IApplicationCommandOverwriteData> commands,
             CancellationToken ct = default
         );
 
@@ -164,10 +161,7 @@ namespace Remora.Discord.API.Abstractions.Rest
         (
             Snowflake applicationID,
             Snowflake guildID,
-            IReadOnlyList
-            <
-                (string Name, string Description, Optional<IReadOnlyList<IApplicationCommandOption>> Options)
-            > commands,
+            IReadOnlyList<IApplicationCommandOverwriteData> commands,
             CancellationToken ct = default
         );
 

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/ApplicationCommandOverwriteData.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/ApplicationCommandOverwriteData.cs
@@ -1,0 +1,40 @@
+//
+//  ApplicationCommandOverwriteData.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.Core;
+
+namespace Remora.Discord.API.Objects
+{
+    /// <inheritdoc cref="IApplicationCommandOverwriteData" />
+    [PublicAPI]
+    public record ApplicationCommandOverwriteData
+    (
+        string Name,
+        string Description,
+        Optional<IReadOnlyList<IApplicationCommandOption>> Options = default,
+        Optional<bool> DefaultPermission = default
+    )
+    : IApplicationCommandOverwriteData;
+}

--- a/Backend/Remora.Discord.Rest/API/Applications/DiscordRestApplicationAPI.cs
+++ b/Backend/Remora.Discord.Rest/API/Applications/DiscordRestApplicationAPI.cs
@@ -119,11 +119,7 @@ namespace Remora.Discord.Rest.API
         public async Task<Result<IReadOnlyList<IApplicationCommand>>> BulkOverwriteGlobalApplicationCommandsAsync
         (
             Snowflake applicationID,
-            IReadOnlyList
-            <
-                (string Name, string Description, Optional<IReadOnlyList<IApplicationCommandOption>> Options)
-            >
-            commands,
+            IReadOnlyList<IApplicationCommandOverwriteData> commands,
             CancellationToken ct = default)
         {
             if (commands.Any(c => c.Name.Length is < 1 or > 32))
@@ -149,12 +145,13 @@ namespace Remora.Discord.Rest.API
                 (
                     json =>
                     {
-                        foreach (var (name, description, options) in commands)
+                        foreach (var command in commands)
                         {
                             json.WriteStartObject();
-                            json.WriteString("name", name);
-                            json.WriteString("description", description);
-                            json.Write("options", options, _jsonOptions);
+                            json.WriteString("name", command.Name);
+                            json.WriteString("description", command.Description);
+                            json.Write("options", command.Options, _jsonOptions);
+                            json.Write("default_permission", command.DefaultPermission);
                             json.WriteEndObject();
                         }
                     }
@@ -254,11 +251,7 @@ namespace Remora.Discord.Rest.API
         (
             Snowflake applicationID,
             Snowflake guildID,
-            IReadOnlyList
-            <
-                (string Name, string Description, Optional<IReadOnlyList<IApplicationCommandOption>> Options)
-            >
-            commands,
+            IReadOnlyList<IApplicationCommandOverwriteData> commands,
             CancellationToken ct = default
         )
         {
@@ -285,12 +278,13 @@ namespace Remora.Discord.Rest.API
                 (
                     json =>
                     {
-                        foreach (var (name, description, options) in commands)
+                        foreach (var command in commands)
                         {
                             json.WriteStartObject();
-                            json.WriteString("name", name);
-                            json.WriteString("description", description);
-                            json.Write("options", options, _jsonOptions);
+                            json.WriteString("name", command.Name);
+                            json.WriteString("description", command.Description);
+                            json.Write("options", command.Options, _jsonOptions);
+                            json.Write("default_permission", command.DefaultPermission);
                             json.WriteEndObject();
                         }
                     }

--- a/Tests/Remora.Discord.Rest.Tests/API/Applications/DiscordRestApplicationAPITests.cs
+++ b/Tests/Remora.Discord.Rest.Tests/API/Applications/DiscordRestApplicationAPITests.cs
@@ -293,11 +293,22 @@ namespace Remora.Discord.Rest.Tests.API.Applications
             public async Task PerformsRequestCorrectly()
             {
                 var applicationID = new Snowflake(0);
-                var name = "aaa";
-                var description = "wwww";
-                Optional<IReadOnlyList<IApplicationCommandOption>> options = new List<ApplicationCommandOption>();
-
-                var commands = new[] { (name, description, options) };
+                var commands = new[]
+                {
+                    new ApplicationCommandOverwriteData(
+                        Name: "aaa",
+                        Description: "bbbb",
+                        Options: new List<ApplicationCommandOption>(),
+                        DefaultPermission: true),
+                    new ApplicationCommandOverwriteData(
+                        Name: "ccc",
+                        Description: "dddd",
+                        Options: new List<ApplicationCommandOption>(),
+                        DefaultPermission: true),
+                    new ApplicationCommandOverwriteData(
+                        Name: "eee",
+                        Description: "ffff")
+                };
 
                 var api = CreateAPI
                 (
@@ -307,16 +318,45 @@ namespace Remora.Discord.Rest.Tests.API.Applications
                         (
                             json => json.IsArray
                             (
-                                a => a.WithSingleElement
-                                (
-                                    e => e.IsObject
+                                a => a
+                                    .WithElement
                                     (
-                                        o => o
-                                            .WithProperty("name", p => p.Is(name))
-                                            .WithProperty("description", p => p.Is(description))
-                                            .WithProperty("options", p => p.IsArray())
+                                        0,
+                                        e => e.IsObject
+                                        (
+                                            o => o
+                                                .WithProperty("name", p => p.Is(commands[0].Name))
+                                                .WithProperty("description", p => p.Is(commands[0].Description))
+                                                .WithProperty("options", p => p.IsArray(
+                                                    a => a.WithCount(0)))
+                                                .WithProperty("default_permission", p => p.Is(commands[0].DefaultPermission.Value))
+                                        )
                                     )
-                                )
+                                    .WithElement
+                                    (
+                                        1,
+                                        e => e.IsObject
+                                        (
+                                            o => o
+                                                .WithProperty("name", p => p.Is(commands[1].Name))
+                                                .WithProperty("description", p => p.Is(commands[1].Description))
+                                                .WithProperty("options", p => p.IsArray(
+                                                    a => a.WithCount(0)))
+                                                .WithProperty("default_permission", p => p.Is(commands[1].DefaultPermission.Value))
+                                        )
+                                    )
+                                    .WithElement
+                                    (
+                                        2,
+                                        e => e.IsObject
+                                        (
+                                            o => o
+                                                .WithProperty("name", p => p.Is(commands[2].Name))
+                                                .WithProperty("description", p => p.Is(commands[2].Description))
+                                                .WithoutProperty("options")
+                                                .WithoutProperty("default_permission")
+                                        )
+                                    )
                             )
                         )
                         .Respond("application/json", "[]")
@@ -339,11 +379,12 @@ namespace Remora.Discord.Rest.Tests.API.Applications
             public async Task ReturnsUnsuccessfulIfNameIsTooShort()
             {
                 var applicationID = new Snowflake(0);
-                var name = string.Empty;
-                var description = "wwww";
-                Optional<IReadOnlyList<IApplicationCommandOption>> options = new List<ApplicationCommandOption>();
-
-                var commands = new[] { (name, description, options) };
+                var commands = new[]
+                {
+                    new ApplicationCommandOverwriteData(
+                        Name: string.Empty,
+                        Description: "wwww")
+                };
 
                 var api = CreateAPI
                 (
@@ -369,11 +410,12 @@ namespace Remora.Discord.Rest.Tests.API.Applications
             public async Task ReturnsUnsuccessfulIfNameIsTooLong()
             {
                 var applicationID = new Snowflake(0);
-                var name = new string('a', 33);
-                var description = "wwww";
-                Optional<IReadOnlyList<IApplicationCommandOption>> options = new List<ApplicationCommandOption>();
-
-                var commands = new[] { (name, description, options) };
+                var commands = new[]
+                {
+                    new ApplicationCommandOverwriteData(
+                        Name: new string('a', 33),
+                        Description: "wwww")
+                };
 
                 var api = CreateAPI
                 (
@@ -399,11 +441,12 @@ namespace Remora.Discord.Rest.Tests.API.Applications
             public async Task ReturnsUnsuccessfulIfDescriptionIsTooShort()
             {
                 var applicationID = new Snowflake(0);
-                var name = "aaa";
-                var description = string.Empty;
-                Optional<IReadOnlyList<IApplicationCommandOption>> options = new List<ApplicationCommandOption>();
-
-                var commands = new[] { (name, description, options) };
+                var commands = new[]
+                {
+                    new ApplicationCommandOverwriteData(
+                        Name: "aaa",
+                        Description: string.Empty)
+                };
 
                 var api = CreateAPI
                 (
@@ -429,11 +472,12 @@ namespace Remora.Discord.Rest.Tests.API.Applications
             public async Task ReturnsUnsuccessfulIfDescriptionIsTooLong()
             {
                 var applicationID = new Snowflake(0);
-                var name = "aaa";
-                var description = new string('a', 101);
-                Optional<IReadOnlyList<IApplicationCommandOption>> options = new List<ApplicationCommandOption>();
-
-                var commands = new[] { (name, description, options) };
+                var commands = new[]
+                {
+                    new ApplicationCommandOverwriteData(
+                        Name: "aaa",
+                        Description: new string('w', 101))
+                };
 
                 var api = CreateAPI
                 (
@@ -1029,11 +1073,22 @@ namespace Remora.Discord.Rest.Tests.API.Applications
             {
                 var applicationID = new Snowflake(0);
                 var guildID = new Snowflake(1);
-                var name = "aaa";
-                var description = "wwww";
-                Optional<IReadOnlyList<IApplicationCommandOption>> options = new List<ApplicationCommandOption>();
-
-                var commands = new[] { (name, description, options) };
+                var commands = new[]
+                {
+                    new ApplicationCommandOverwriteData(
+                        Name: "aaa",
+                        Description: "bbbb",
+                        Options: new List<ApplicationCommandOption>(),
+                        DefaultPermission: true),
+                    new ApplicationCommandOverwriteData(
+                        Name: "ccc",
+                        Description: "dddd",
+                        Options: new List<ApplicationCommandOption>(),
+                        DefaultPermission: false),
+                    new ApplicationCommandOverwriteData(
+                        Name: "eee",
+                        Description: "ffff"),
+                };
 
                 var api = CreateAPI
                 (
@@ -1043,16 +1098,45 @@ namespace Remora.Discord.Rest.Tests.API.Applications
                         (
                             json => json.IsArray
                             (
-                                a => a.WithSingleElement
-                                (
-                                    e => e.IsObject
+                                a => a
+                                    .WithElement
                                     (
-                                        o => o
-                                            .WithProperty("name", p => p.Is(name))
-                                            .WithProperty("description", p => p.Is(description))
-                                            .WithProperty("options", p => p.IsArray())
+                                        0,
+                                        e => e.IsObject
+                                        (
+                                            o => o
+                                                .WithProperty("name", p => p.Is(commands[0].Name))
+                                                .WithProperty("description", p => p.Is(commands[0].Description))
+                                                .WithProperty("options", p => p.IsArray(
+                                                    a => a.WithCount(0)))
+                                                .WithProperty("default_permission", p => p.Is(commands[0].DefaultPermission.Value))
+                                        )
                                     )
-                                )
+                                    .WithElement
+                                    (
+                                        1,
+                                        e => e.IsObject
+                                        (
+                                            o => o
+                                                .WithProperty("name", p => p.Is(commands[1].Name))
+                                                .WithProperty("description", p => p.Is(commands[1].Description))
+                                                .WithProperty("options", p => p.IsArray(
+                                                    a => a.WithCount(0)))
+                                                .WithProperty("default_permission", p => p.Is(commands[1].DefaultPermission.Value))
+                                        )
+                                    )
+                                    .WithElement
+                                    (
+                                        2,
+                                        e => e.IsObject
+                                        (
+                                            o => o
+                                                .WithProperty("name", p => p.Is(commands[2].Name))
+                                                .WithProperty("description", p => p.Is(commands[2].Description))
+                                                .WithoutProperty("options")
+                                                .WithoutProperty("default_permission")
+                                        )
+                                    )
                             )
                         )
                         .Respond("application/json", "[]")
@@ -1077,11 +1161,12 @@ namespace Remora.Discord.Rest.Tests.API.Applications
             {
                 var applicationID = new Snowflake(0);
                 var guildID = new Snowflake(1);
-                var name = string.Empty;
-                var description = "wwww";
-                Optional<IReadOnlyList<IApplicationCommandOption>> options = new List<ApplicationCommandOption>();
-
-                var commands = new[] { (name, description, options) };
+                var commands = new[]
+                {
+                    new ApplicationCommandOverwriteData(
+                        Name: string.Empty,
+                        Description: "wwww")
+                };
 
                 var api = CreateAPI
                 (
@@ -1109,11 +1194,12 @@ namespace Remora.Discord.Rest.Tests.API.Applications
             {
                 var applicationID = new Snowflake(0);
                 var guildID = new Snowflake(1);
-                var name = new string('a', 33);
-                var description = "wwww";
-                Optional<IReadOnlyList<IApplicationCommandOption>> options = new List<ApplicationCommandOption>();
-
-                var commands = new[] { (name, description, options) };
+                var commands = new[]
+                {
+                    new ApplicationCommandOverwriteData(
+                        Name: new string('a', 33),
+                        Description: "wwww")
+                };
 
                 var api = CreateAPI
                 (
@@ -1141,11 +1227,12 @@ namespace Remora.Discord.Rest.Tests.API.Applications
             {
                 var applicationID = new Snowflake(0);
                 var guildID = new Snowflake(1);
-                var name = "aaa";
-                var description = string.Empty;
-                Optional<IReadOnlyList<IApplicationCommandOption>> options = new List<ApplicationCommandOption>();
-
-                var commands = new[] { (name, description, options) };
+                var commands = new[]
+                {
+                    new ApplicationCommandOverwriteData(
+                        Name: "aaa",
+                        Description: string.Empty)
+                };
 
                 var api = CreateAPI
                 (
@@ -1173,11 +1260,12 @@ namespace Remora.Discord.Rest.Tests.API.Applications
             {
                 var applicationID = new Snowflake(0);
                 var guildID = new Snowflake(1);
-                var name = "aaa";
-                var description = new string('a', 101);
-                Optional<IReadOnlyList<IApplicationCommandOption>> options = new List<ApplicationCommandOption>();
-
-                var commands = new[] { (name, description, options) };
+                var commands = new[]
+                {
+                    new ApplicationCommandOverwriteData(
+                        Name: "aaa",
+                        Description: new string('a', 101))
+                };
 
                 var api = CreateAPI
                 (

--- a/Tests/Remora.Discord.Rest.Tests/Json/JsonObjectMatcherBuilder.cs
+++ b/Tests/Remora.Discord.Rest.Tests/Json/JsonObjectMatcherBuilder.cs
@@ -76,6 +76,26 @@ namespace Remora.Discord.Rest.Tests.Json
         }
 
         /// <summary>
+        /// Adds a requirement that a given property should not exist.
+        /// </summary>
+        /// <param name="name">The name of the property.</param>
+        /// <returns>The builder, with the requirement.</returns>
+        public JsonObjectMatcherBuilder WithoutProperty
+        (
+            string name
+        )
+        {
+            _matchers.Add
+            (
+                obj => obj.TryGetProperty(name, out var property)
+                    ? throw new Xunit.Sdk.DoesNotContainException(name, obj)
+                    : true
+            );
+
+            return this;
+        }
+
+        /// <summary>
         /// Builds the object matcher.
         /// </summary>
         /// <returns>The built object matcher.</returns>


### PR DESCRIPTION
Enhanced the Rest Applications API to include the "default_permission" parameter when bulk overwriting commands, and to reduce verbosity.