### PR TITLE
Reworked and enhanced the logic for translating Remora command trees into Discord command trees.

### DIFF
--- a/Remora.Discord.Commands/Services/SlashService.cs
+++ b/Remora.Discord.Commands/Services/SlashService.cs
@@ -101,18 +101,6 @@ namespace Remora.Discord.Commands.Services
                 return Result.FromError(createCommands);
             }
 
-            var commands = createCommands.Entity
-                .Select
-                (
-                    c => new BulkApplicationCommandData
-                    (
-                        c.Name,
-                        c.Description,
-                        c.Options
-                    )
-                )
-                .ToArray();
-
             // Upsert the current valid command set
             var updateResult = await
             (
@@ -120,14 +108,14 @@ namespace Remora.Discord.Commands.Services
                     ? _applicationAPI.BulkOverwriteGlobalApplicationCommandsAsync
                     (
                         application.ID,
-                        commands,
+                        createCommands.Entity,
                         ct
                     )
                     : _applicationAPI.BulkOverwriteGuildApplicationCommandsAsync
                     (
                         application.ID,
                         guildID.Value,
-                        commands,
+                        createCommands.Entity,
                         ct
                     )
             );

--- a/Tests/Remora.Discord.Commands.Tests/Extensions/CommandTreeExtensionTests.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Extensions/CommandTreeExtensionTests.cs
@@ -256,10 +256,10 @@ namespace Remora.Discord.Commands.Tests.Extensions
                     Assert.NotNull(commands);
                     Assert.Equal(2, commands!.Count);
 
-                    var topLevelCommand = commands.FirstOrDefault(c => c.Type == SubCommand);
+                    var topLevelCommand = commands.FirstOrDefault(c => c.Name == "top-level-command");
                     Assert.NotNull(topLevelCommand);
 
-                    var topLevelGroup = commands.FirstOrDefault(c => c.Type == SubCommandGroup);
+                    var topLevelGroup = commands.FirstOrDefault(c => c.Name == "top-level-group");
                     Assert.NotNull(topLevelGroup);
 
                     Assert.True(topLevelGroup!.Options.HasValue);
@@ -406,7 +406,6 @@ namespace Remora.Discord.Commands.Tests.Extensions
 
                     var group = commands.Single();
 
-                    Assert.Equal(SubCommandGroup, group.Type);
                     Assert.Equal("a", group.Name);
 
                     Assert.Collection
@@ -437,7 +436,6 @@ namespace Remora.Discord.Commands.Tests.Extensions
 
                     var group = commands.Single();
 
-                    Assert.Equal(SubCommandGroup, group.Type);
                     Assert.Equal("a", group.Name);
 
                     var nestedGroup = group.Options.Value!.Single();
@@ -491,7 +489,6 @@ namespace Remora.Discord.Commands.Tests.Extensions
 
                     var group = commands.Single();
 
-                    Assert.Equal(SubCommandGroup, group.Type);
                     Assert.Equal("a", group.Name);
 
                     Assert.Collection


### PR DESCRIPTION
The translation now returns IBulkApplicationCommandData at the top level, rather than IApplicationCommandOption, to better reflect the Discord API model.

Other enhancements include consolidation of validation logic and error message generation, minor performance improvements in aggregate validations, such as counting and name-collision detection, and restructuring of private methods to properly leverage Result<T>, and eliminate null-check overrides.