### PR TITLE
Enhanced Optional<T> to support meaningful stringification.

### DIFF
--- a/Backend/Remora.Discord.Core/Optional.cs
+++ b/Backend/Remora.Discord.Core/Optional.cs
@@ -23,7 +23,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 
 namespace Remora.Discord.Core
@@ -37,7 +36,7 @@ namespace Remora.Discord.Core
     /// value would never be serialized, but a nullable with a null value would (albeit as "null").
     /// </summary>
     /// <typeparam name="TValue">The inner type.</typeparam>
-    [PublicAPI, DebuggerDisplay("{" + nameof(DebuggerDisplay) + ",nq}")]
+    [PublicAPI]
     public readonly struct Optional<TValue> : IOptional
     {
         private readonly TValue _value;
@@ -62,20 +61,6 @@ namespace Remora.Discord.Core
 
         /// <inheritdoc />
         public bool HasValue { get; }
-
-        [DebuggerHidden, ExcludeFromCodeCoverage]
-        private string DebuggerDisplay
-        {
-            get
-            {
-                if (this.HasValue)
-                {
-                    return this.Value?.ToString() ?? "null";
-                }
-
-                return "Empty";
-            }
-        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Optional{TValue}"/> struct.
@@ -135,6 +120,14 @@ namespace Remora.Discord.Core
         public override int GetHashCode()
         {
             return HashCode.Combine(_value, this.HasValue);
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return this.HasValue
+                ? $"{{{_value?.ToString() ?? "null"}}}"
+                : "Empty";
         }
     }
 }

--- a/Tests/Remora.Discord.Tests/Tests/Core/Optional/OptionalTests.cs
+++ b/Tests/Remora.Discord.Tests/Tests/Core/Optional/OptionalTests.cs
@@ -199,6 +199,92 @@ namespace Remora.Discord.Tests.Tests.Core
         }
 
         /// <summary>
+        /// Tests the <see cref="Optional{TValue}.ToString"/> method.
+        /// </summary>
+        public new class ToString
+        {
+            [Fact]
+            public void ResultContainsValueIfValueTypeOptionalContainsValue()
+            {
+                var optional = new Optional<int>(64);
+
+                Assert.Contains(64.ToString(), optional.ToString());
+            }
+
+            [Fact]
+            public void ResultIsEmptyIfValueTypeOptionalDoesNotContainValue()
+            {
+                var optional = default(Optional<int>);
+
+                Assert.Equal("Empty", optional.ToString());
+            }
+
+            [Fact]
+            public void ResultContainsValueIfNullableValueTypeOptionalContainsValue()
+            {
+                var optional = new Optional<int?>(64);
+
+                Assert.Contains(64.ToString(), optional.ToString());
+            }
+
+            [Fact]
+            public void ResultContainsNullIfNullableValueTypeOptionalContainsNullValue()
+            {
+                var optional = new Optional<int?>(null);
+
+                Assert.Contains("null", optional.ToString());
+            }
+
+            [Fact]
+            public void ResultIsEmptyIfNullableValueTypeOptionalDoesNotContainValue()
+            {
+                var optional = default(Optional<int?>);
+
+                Assert.Equal("Empty", optional.ToString());
+            }
+
+            [Fact]
+            public void ResultContainsValueIfReferenceTypeOptionalContainsValue()
+            {
+                var optional = new Optional<string>("Hello world!");
+
+                Assert.Contains("Hello world!", optional.ToString());
+            }
+
+            [Fact]
+            public void ResultIsEmptyIfReferenceTypeOptionalDoesNotContainValue()
+            {
+                var optional = default(Optional<string>);
+
+                Assert.Equal("Empty", optional.ToString());
+            }
+
+            [Fact]
+            public void ResultContainsValueIfNullableReferenceTypeOptionalContainsValue()
+            {
+                var optional = new Optional<string?>("Hello world!");
+
+                Assert.Contains("Hello world!", optional.ToString());
+            }
+
+            [Fact]
+            public void ResultContainsNullIfNullableReferenceTypeOptionalContainsNullValue()
+            {
+                var optional = new Optional<string?>(null);
+
+                Assert.Contains("null", optional.ToString());
+            }
+
+            [Fact]
+            public void ResultIsEmptyIfNullableReferenceTypeOptionalDoesNotContainValue()
+            {
+                var optional = default(Optional<string?>);
+
+                Assert.Equal("Empty", optional.ToString());
+            }
+        }
+
+        /// <summary>
         /// Tests the implicit operator.
         /// </summary>
         public class ImplicitOperator


### PR DESCRIPTION
So, hear me out. I encountered the need to write the following while building out logging infrastructure...

```cs
=> _userTracking.Invoke(
    logger,
    userId,
    guildId,
    username.HasValue
        ? username.Value.ToString()
        : "Unspecified",
    discriminator.HasValue
        ? discrimincator.Value.ToString()
        : "Unspecified",
    avatarHash.HasValue
        ? avatarHash.Value.ToString()
        : "Unspecified",
    nickname.HasValue
        ? nickname.Value.ToString()
        : "Unspecified");
```

This is necessary because I can't reasonably configure all logger sinks to know how to serialize an `Optional<T>` value, especially those that attempt to JSON-serialize objects. Instead, they'll try and read from `.Value` and cause an exception in logging.

I'm usually a fan of not having debugging logic embedded in a type, so I generally like `DebuggerDisplay` myself, but for a type that is borderline "primitive" I think there's a fair bit of value in giving it a somewhat-meaningful `.ToString()` implementation.