### PR TITLE
Fixed the missing field in IPartialVoiceState.

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Voice/IPartialVoiceState.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Voice/IPartialVoiceState.cs
@@ -20,6 +20,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+using System;
 using JetBrains.Annotations;
 using Remora.Discord.Core;
 
@@ -90,5 +91,10 @@ namespace Remora.Discord.API.Abstractions.Objects
         /// Gets a value indicating whether the user is muted by the current user.
         /// </summary>
         Optional<bool> IsSuppressed { get; }
+
+        /// <summary>
+        /// Gets the time at which the user requested to speak.
+        /// </summary>
+        Optional<DateTimeOffset?> RequestToSpeakTimestamp { get; }
     }
 }

--- a/Backend/Remora.Discord.API/API/Objects/Voice/PartialVoiceState.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Voice/PartialVoiceState.cs
@@ -20,6 +20,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+using System;
 using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.Core;
@@ -43,6 +44,7 @@ namespace Remora.Discord.API.Objects
         Optional<bool> IsSelfMuted = default,
         Optional<bool> IsStreaming = default,
         Optional<bool> IsVideoEnabled = default,
-        Optional<bool> IsSuppressed = default
+        Optional<bool> IsSuppressed = default,
+        Optional<DateTimeOffset?> RequestToSpeakTimestamp = default
     ) : IPartialVoiceState;
 }


### PR DESCRIPTION
IVoiceState has a RequestToSpeakTimestamp field, but IPartialVoiceState does not.
This PR will add the missing field.