### PR TITLE
Fixed the value of ShardingRequired.

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Gateway/GatewayCloseStatus.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Gateway/GatewayCloseStatus.cs
@@ -83,7 +83,7 @@ namespace Remora.Discord.API.Abstractions.Gateway
         /// <summary>
         /// Sharding is required by this session.
         /// </summary>
-        ShardingRequired = 40011,
+        ShardingRequired = 4011,
 
         /// <summary>
         /// An invalid API version was sent to the gateway.


### PR DESCRIPTION
The value of GatewayCloseStatus.ShardingRequired is different from the document.
This PR will fix it.

document: https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes