### PR TITLE
[WIP] Rework pre- and post-execution event API

### DIFF
--- a/Remora.Discord.Commands/Contexts/InteractionContext.cs
+++ b/Remora.Discord.Commands/Contexts/InteractionContext.cs
@@ -41,7 +41,7 @@ namespace Remora.Discord.Commands.Contexts
         string Token,
         Snowflake ID,
         Snowflake ApplicationID,
-        Optional<IApplicationCommandInteractionDataResolved> Resolved
+        IApplicationCommandInteractionData Data
     )
     : CommandContext(GuildID, ChannelID, User);
 }

--- a/Remora.Discord.Commands/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/ServiceCollectionExtensions.cs
@@ -60,6 +60,7 @@ namespace Remora.Discord.Commands.Extensions
             serviceCollection
                 .TryAddScoped<ContextInjectionService>();
 
+            // Set up context injection
             serviceCollection
                 .TryAddTransient<ICommandContext>
                 (
@@ -113,7 +114,7 @@ namespace Remora.Discord.Commands.Extensions
                 .AddParser<IUser, UserParser>()
                 .AddParser<Snowflake, SnowflakeParser>();
 
-            serviceCollection.TryAddScoped<ExecutionEventCollectorService>();
+            serviceCollection.TryAddSingleton<ExecutionEventCollectorService>();
 
             serviceCollection.TryAddScoped<FeedbackService>();
             serviceCollection.AddSingleton(FeedbackTheme.DiscordLight);
@@ -160,6 +161,48 @@ namespace Remora.Discord.Commands.Extensions
 
             serviceCollection.AddResponder<InteractionResponder>();
             serviceCollection.Configure(optionsConfigurator);
+
+            return serviceCollection;
+        }
+
+        /// <summary>
+        /// Adds a pre-execution event to the service collection.
+        /// </summary>
+        /// <param name="serviceCollection">The service collection.</param>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <returns>The collection, with the event.</returns>
+        public static IServiceCollection AddPreExecutionEvent<TEvent>(this IServiceCollection serviceCollection)
+            where TEvent : class, IPreExecutionEvent
+        {
+            serviceCollection.AddScoped<IPreExecutionEvent, TEvent>();
+            return serviceCollection;
+        }
+
+        /// <summary>
+        /// Adds a post-execution event to the service collection.
+        /// </summary>
+        /// <param name="serviceCollection">The service collection.</param>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <returns>The collection, with the event.</returns>
+        public static IServiceCollection AddPostExecutionEvent<TEvent>(this IServiceCollection serviceCollection)
+            where TEvent : class, IPostExecutionEvent
+        {
+            serviceCollection.AddScoped<IPostExecutionEvent, TEvent>();
+            return serviceCollection;
+        }
+
+        /// <summary>
+        /// Adds a pre- and post-execution event to the service collection.
+        /// </summary>
+        /// <param name="serviceCollection">The service collection.</param>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <returns>The collection, with the event.</returns>
+        public static IServiceCollection AddExecutionEvent<TEvent>(this IServiceCollection serviceCollection)
+            where TEvent : class, IPreExecutionEvent, IPostExecutionEvent
+        {
+            serviceCollection
+                .AddPreExecutionEvent<TEvent>()
+                .AddPostExecutionEvent<TEvent>();
 
             return serviceCollection;
         }

--- a/Remora.Discord.Commands/Remora.Discord.Commands.csproj.DotSettings
+++ b/Remora.Discord.Commands/Remora.Discord.Commands.csproj.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=conditions_005Cattributes/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=conditions_005Cattributes/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services_005Cexecution/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Remora.Discord.Commands/Responders/CommandResponder.cs
+++ b/Remora.Discord.Commands/Responders/CommandResponder.cs
@@ -220,7 +220,7 @@ namespace Remora.Discord.Commands.Responders
             }
 
             // Run any user-provided pre execution events
-            var preExecution = await _eventCollector.RunPreExecutionEvents(commandContext, ct);
+            var preExecution = await _eventCollector.RunPreExecutionEvents(_services, commandContext, ct);
             if (!preExecution.IsSuccess)
             {
                 return preExecution;
@@ -242,6 +242,7 @@ namespace Remora.Discord.Commands.Responders
             // Run any user-provided post execution events
             var postExecution = await _eventCollector.RunPostExecutionEvents
             (
+                _services,
                 commandContext,
                 executeResult.Entity,
                 ct

--- a/Remora.Discord.Commands/Responders/CommandResponder.cs
+++ b/Remora.Discord.Commands/Responders/CommandResponder.cs
@@ -234,6 +234,8 @@ namespace Remora.Discord.Commands.Responders
                 ct: ct
             );
 
+            // Note to self: this doesn't check whether the *command* succeeded, it checks whether *execution*
+            // succeeded. This is why we return here, and why post-execution events still run for unsuccessful commands.
             if (!executeResult.IsSuccess)
             {
                 return Result.FromError(executeResult);

--- a/Remora.Discord.Commands/Responders/InteractionResponder.cs
+++ b/Remora.Discord.Commands/Responders/InteractionResponder.cs
@@ -173,6 +173,8 @@ namespace Remora.Discord.Commands.Responders
                 ct: ct
             );
 
+            // Note to self: this doesn't check whether the *command* succeeded, it checks whether *execution*
+            // succeeded. This is why we return here, and why post-execution events still run for unsuccessful commands.
             if (!executeResult.IsSuccess)
             {
                 return Result.FromError(executeResult);

--- a/Remora.Discord.Commands/Responders/InteractionResponder.cs
+++ b/Remora.Discord.Commands/Responders/InteractionResponder.cs
@@ -149,7 +149,7 @@ namespace Remora.Discord.Commands.Responders
                 gatewayEvent.Token,
                 gatewayEvent.ID,
                 gatewayEvent.ApplicationID,
-                interactionData.Resolved
+                interactionData
             );
 
             // Provide the created context to any services inside this scope

--- a/Remora.Discord.Commands/Responders/InteractionResponder.cs
+++ b/Remora.Discord.Commands/Responders/InteractionResponder.cs
@@ -156,7 +156,7 @@ namespace Remora.Discord.Commands.Responders
             _contextInjection.Context = context;
 
             // Run any user-provided pre execution events
-            var preExecution = await _eventCollector.RunPreExecutionEvents(context, ct);
+            var preExecution = await _eventCollector.RunPreExecutionEvents(_services, context, ct);
             if (!preExecution.IsSuccess)
             {
                 return preExecution;
@@ -181,6 +181,7 @@ namespace Remora.Discord.Commands.Responders
             // Run any user-provided post execution events
             return await _eventCollector.RunPostExecutionEvents
             (
+                _services,
                 context,
                 executeResult.Entity,
                 ct

--- a/Remora.Discord.Commands/Services/Execution/IPostExecutionEvent.cs
+++ b/Remora.Discord.Commands/Services/Execution/IPostExecutionEvent.cs
@@ -36,13 +36,13 @@ namespace Remora.Discord.Commands.Services
         /// Runs after a command has been executed, successfully or otherwise.
         /// </summary>
         /// <param name="context">The command context.</param>
-        /// <param name="executionResult">The result of the execution.</param>
+        /// <param name="commandResult">The result returned by the command.</param>
         /// <param name="ct">The cancellation token of the current operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task<Result> AfterExecutionAsync
         (
             ICommandContext context,
-            IResult executionResult,
+            IResult commandResult,
             CancellationToken ct = default
         );
     }

--- a/Remora.Discord.Commands/Services/Execution/IPostExecutionEvent.cs
+++ b/Remora.Discord.Commands/Services/Execution/IPostExecutionEvent.cs
@@ -1,5 +1,5 @@
 //
-//  IExecutionEventService.cs
+//  IPostExecutionEvent.cs
 //
 //  Author:
 //       Jarl Gullberg <jarl.gullberg@gmail.com>
@@ -22,28 +22,18 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 using Remora.Discord.Commands.Contexts;
 using Remora.Results;
 
 namespace Remora.Discord.Commands.Services
 {
     /// <summary>
-    /// Defines the public API for a service that performs actions related to command execution.
+    /// Represents the public interface of a service that can perform a post-execution event.
     /// </summary>
-    [PublicAPI]
-    public interface IExecutionEventService
+    public interface IPostExecutionEvent
     {
         /// <summary>
-        /// Runs before the attempted execution of a command.
-        /// </summary>
-        /// <param name="context">The command context.</param>
-        /// <param name="ct">The cancellation token of the current operation.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task<Result> BeforeExecutionAsync(ICommandContext context, CancellationToken ct = default);
-
-        /// <summary>
-        /// Runs after a command has been successfully executed.
+        /// Runs after a command has been executed, successfully or otherwise.
         /// </summary>
         /// <param name="context">The command context.</param>
         /// <param name="executionResult">The result of the execution.</param>

--- a/Remora.Discord.Commands/Services/Execution/IPreExecutionEvent.cs
+++ b/Remora.Discord.Commands/Services/Execution/IPreExecutionEvent.cs
@@ -1,0 +1,45 @@
+//
+//  IPreExecutionEvent.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Remora.Discord.Commands.Contexts;
+using Remora.Results;
+
+namespace Remora.Discord.Commands.Services
+{
+    /// <summary>
+    /// Represents the public interface of a service that can perform a pre-execution event.
+    /// </summary>
+    [PublicAPI]
+    public interface IPreExecutionEvent
+    {
+        /// <summary>
+        /// Runs before the attempted execution of a command.
+        /// </summary>
+        /// <param name="context">The command context.</param>
+        /// <param name="ct">The cancellation token of the current operation.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task<Result> BeforeExecutionAsync(ICommandContext context, CancellationToken ct = default);
+    }
+}

--- a/Tests/Remora.Discord.Commands.Tests/ContextTests.cs
+++ b/Tests/Remora.Discord.Commands.Tests/ContextTests.cs
@@ -100,7 +100,7 @@ namespace Remora.Discord.Commands.Tests
         [Fact]
         public async Task CanExecuteCommandFromGroupThatWantsInteractionContext()
         {
-            var dummyContext = new InteractionContext(default, default, null!, default, null!, default, default, default);
+            var dummyContext = new InteractionContext(default, default, null!, default, null!, default, default, null!);
             _contextInjection.Context = dummyContext;
 
             var result = await _commands.TryExecuteAsync("interaction command", _services);


### PR DESCRIPTION
This PR reworks the pre- and post-execution event API, making it a bit less tedious to work with. Furthermore, it also alters `InteractionContext`, providing more data useful to both command implementations and execution events.