### PR TITLE
Fix the settings shared by each project.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -102,7 +102,7 @@
             <Link>stylecop.json</Link>
             <InProject>false</InProject>
         </AdditionalFiles>
-        <AdditionalFiles Include="$(StyleCopRuleset">
+        <AdditionalFiles Include="$(StyleCopRuleset)">
             <Link>stylecop.ruleset</Link>
             <InProject>false</InProject>
         </AdditionalFiles>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,10 +14,6 @@
         <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     </PropertyGroup>
 
-    <PropertyGroup>
-        <SolutionDir>$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)/))</SolutionDir>
-    </PropertyGroup>
-
     <!-- NuGet-related properties -->
     <PropertyGroup>
         <Title>$(AssemblyName)</Title>
@@ -35,7 +31,7 @@
 
         <RepositoryUrl>https://github.com/Nihlus/Remora.Discord</RepositoryUrl>
         <RepositoryBranch>master</RepositoryBranch>
-        <PackageOutputPath>$(SolutionDir)/nuget</PackageOutputPath>
+        <PackageOutputPath>$(MSBuildThisFileDirectory)nuget</PackageOutputPath>
         <PackageProjectUrl>https://github.com/Nihlus/Remora.Discord</PackageProjectUrl>
         <PackageTags>discord;bot;api;</PackageTags>
         <PackageIconUrl>https://cdn.gullberg.tk/remora/icon/shark.png</PackageIconUrl>
@@ -48,8 +44,8 @@
 
     <!-- Code inspection properties -->
     <PropertyGroup>
-        <StyleCopRuleset>$(SolutionDir)/stylecop.ruleset</StyleCopRuleset>
-        <StyleCopConfiguration>$(SolutionDir)/stylecop.json</StyleCopConfiguration>
+        <StyleCopRuleset>$(MSBuildThisFileDirectory)stylecop.ruleset</StyleCopRuleset>
+        <StyleCopConfiguration>$(MSBuildThisFileDirectory)stylecop.json</StyleCopConfiguration>
 
         <Nullable>enable</Nullable>
 
@@ -126,6 +122,6 @@
 
     <!-- NuGet Icon -->
     <ItemGroup>
-        <None Include="$(SolutionDir)/images/shark.png" Pack="true" PackagePath="/" />
+        <None Include="$(MSBuildThisFileDirectory)images/shark.png" Pack="true" PackagePath="/" />
     </ItemGroup>
 </Project>

--- a/stylecop.ruleset
+++ b/stylecop.ruleset
@@ -87,7 +87,6 @@
     <Rule Id="SA1208" Action="Error" /> <!-- System using directives must be placed before other using directives -->
     <Rule Id="SA1209" Action="Error" /> <!-- Using alias directives must be placed after other using directives -->
     <Rule Id="SA1210" Action="Error" /> <!-- Using directives must be ordered alphabetically by namespace -->
-    <Rule Id="SA1210" Action="Error" /> <!-- Using directives must be ordered alphabetically by namespace -->
     <Rule Id="SA1211" Action="Error" /> <!-- Using alias directives must be ordered alphabetically by alias name -->
     <Rule Id="SA1212" Action="Error" /> <!-- Property accessors must follow order -->
     <Rule Id="SA1213" Action="Error" /> <!-- Event accessors must follow order -->


### PR DESCRIPTION
This PR fixes a few issues in the settings shared by each project.
These issues are encountered in Visual Studio 2019 (ver 16.11.1).

- Cannot find the `stylecop.ruleset` file in the IDE.
- Cannot edit the `stylecop.ruleset` file in the IDE because it says there are duplicate rules.
- Cannot build when using the shared project feature because the `stylecop.json` file is required to be in the root of the solution.