### PR TITLE
Fix send/receive gateway tasks never completing

### DIFF
--- a/Backend/Remora.Discord.Gateway/DiscordGatewayClient.cs
+++ b/Backend/Remora.Discord.Gateway/DiscordGatewayClient.cs
@@ -231,7 +231,7 @@ namespace Remora.Discord.Gateway
 
                     if (_transportService.IsConnected)
                     {
-                        var disconnectResult = await _transportService.DisconnectAsync(stopRequested.IsCancellationRequested, stopRequested);
+                        var disconnectResult = await _transportService.DisconnectAsync(!stopRequested.IsCancellationRequested, stopRequested);
                         if (!disconnectResult.IsSuccess)
                         {
                             // Couldn't disconnect cleanly :(
@@ -525,17 +525,28 @@ namespace Remora.Discord.Gateway
                         }
                     }
 
-                    await Task.Delay(TimeSpan.FromMilliseconds(10), stopRequested);
+                    try
+                    {
+                        await Task.Delay(TimeSpan.FromMilliseconds(10), stopRequested);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // will cleanup below
+                    }
+
                     break;
                 }
             }
 
-            if (!_shouldReconnect)
+            if (!stopRequested.IsCancellationRequested)
             {
-                return Result.FromSuccess();
-            }
+                if (!_shouldReconnect)
+                {
+                    return Result.FromSuccess();
+                }
 
-            _log.LogInformation("Reconnection requested by the gateway; terminating session...");
+                _log.LogInformation("Reconnection requested by the gateway; terminating session...");
+            }
 
             // Terminate the send and receive tasks
             _disconnectRequestedSource.Cancel();
@@ -545,7 +556,7 @@ namespace Remora.Discord.Gateway
             _ = await _sendTask;
             _ = await _receiveTask;
 
-            var disconnectResult = await _transportService.DisconnectAsync(true, stopRequested);
+            var disconnectResult = await _transportService.DisconnectAsync(!stopRequested.IsCancellationRequested, stopRequested);
             if (!disconnectResult.IsSuccess)
             {
                 return disconnectResult;

--- a/Backend/Remora.Discord.Gateway/Transport/WebSocketPayloadTransportService.cs
+++ b/Backend/Remora.Discord.Gateway/Transport/WebSocketPayloadTransportService.cs
@@ -266,6 +266,10 @@ namespace Remora.Discord.Gateway.Transport
                     {
                         // Most likely due to some kind of premature or forced disconnection; we'll live with it
                     }
+                    catch (OperationCanceledException)
+                    {
+                        // We still need to cleanup the socket
+                    }
 
                     break;
                 }


### PR DESCRIPTION
If RunAsync was called with an already cancelled token, this delay would throw an improperly handled TaskCanceledException. As a result, regular cleanup would be bypassed.

Also fixed certain transport service disconnect calls indicating they will reconnect when they won't.

This ensures the path of disconnection is followed as if the gateway itself requested it.