### PR TITLE
Add handling of mentions for SnowflakeParser

### DIFF
--- a/Remora.Discord.Commands/Parsers/SnowflakeParser.cs
+++ b/Remora.Discord.Commands/Parsers/SnowflakeParser.cs
@@ -25,6 +25,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Remora.Commands.Parsers;
 using Remora.Commands.Results;
+using Remora.Discord.Commands.Extensions;
 using Remora.Discord.Core;
 using Remora.Results;
 
@@ -41,7 +42,7 @@ namespace Remora.Discord.Commands.Parsers
         {
             return new
             (
-                !Snowflake.TryParse(value, out var snowflake)
+                !Snowflake.TryParse(value.Unmention(), out var snowflake)
                     ? new ParsingError<Snowflake>(value)
                     : snowflake.Value
             );

--- a/Tests/Remora.Discord.Commands.Tests/Parsers/SnowflakeParserTests.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Parsers/SnowflakeParserTests.cs
@@ -1,0 +1,87 @@
+//
+//  SnowflakeParserTests.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Threading.Tasks;
+using Remora.Discord.Commands.Parsers;
+using Remora.Discord.Tests;
+using Xunit;
+
+namespace Remora.Discord.Commands.Tests.Parsers
+{
+    /// <summary>
+    /// Tests the <see cref="SnowflakeParser"/> class.
+    /// </summary>
+    public class SnowflakeParserTests
+    {
+        private readonly SnowflakeParser _parser;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SnowflakeParserTests"/> class.
+        /// </summary>
+        public SnowflakeParserTests()
+        {
+            _parser = new SnowflakeParser();
+        }
+
+        /// <summary>
+        /// Tests whether the parser returns error on invalid value.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CannotParseInvalidValue()
+        {
+            var tryParse = await _parser.TryParseAsync("invalid");
+            ResultAssert.Unsuccessful(tryParse);
+        }
+
+        /// <summary>
+        /// Tests whether the parser can parse snowflake value given by number.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CanParseSnowflakeByNumber()
+        {
+            ulong snowflakeValue = 6823586735728;
+            var tryParse = await _parser.TryParseAsync(snowflakeValue.ToString());
+            ResultAssert.Successful(tryParse);
+            Assert.Equal(snowflakeValue, tryParse.Entity.Value);
+        }
+
+        /// <summary>
+        /// Tests whether the parser can parse snowflake value given by mentions.
+        /// </summary>
+        /// <param name="value">Mention that should be parsed correctly.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [InlineData("<@135347310845624320>")]
+        [InlineData("<@!135347310845624320>")]
+        [InlineData("<#135347310845624320>")]
+        [InlineData("<@&135347310845624320>")]
+        [Theory]
+        public async Task CanParseSnowflakeByMention(string value)
+        {
+            ulong snowflakeValue = 135347310845624320;
+            var tryParse = await _parser.TryParseAsync(value);
+            ResultAssert.Successful(tryParse);
+            Assert.Equal(snowflakeValue, tryParse.Entity.Value);
+        }
+    }
+}


### PR DESCRIPTION
Snowflake parser could not handle mentions, only raw values. That meant slightly different behavior for interaction commands (user can choose the role/channel/user from a list - supply it as "mention"), but for message commands it would work with plain number only.

I also added some tests, I couldn't find any for `SnowflakeParser`, tell me if changing anything in them is needed.