### PR TITLE
Explicitly implement partial variants of interfaces

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Applications/IApplication.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Applications/IApplication.cs
@@ -30,96 +30,150 @@ namespace Remora.Discord.API.Abstractions.Objects
     /// Represents information about an OAuth2 application.
     /// </summary>
     [PublicAPI]
-    public interface IApplication
+    public interface IApplication : IPartialApplication
     {
         /// <summary>
         /// Gets the application ID.
         /// </summary>
-        Snowflake ID { get; }
+        new Snowflake ID { get; }
 
         /// <summary>
         /// Gets the name of the application.
         /// </summary>
-        string Name { get; }
+        new string Name { get; }
 
         /// <summary>
         /// Gets the icon hash of the application.
         /// </summary>
-        IImageHash? Icon { get; }
+        new IImageHash? Icon { get; }
 
         /// <summary>
         /// Gets the description of the application.
         /// </summary>
-        string Description { get; }
+        new string Description { get; }
 
         /// <summary>
         /// Gets a list of RPC origin URLs.
         /// </summary>
-        Optional<IReadOnlyList<string>> RPCOrigins { get; }
+        new Optional<IReadOnlyList<string>> RPCOrigins { get; }
 
         /// <summary>
         /// Gets a value indicating whether the bot is a public bot.
         /// </summary>
-        bool IsBotPublic { get; }
+        new bool IsBotPublic { get; }
 
         /// <summary>
         /// Gets a value indicating whether the bot will only join upon completion of a full OAuth2 flow.
         /// </summary>
-        bool DoesBotRequireCodeGrant { get; }
+        new bool DoesBotRequireCodeGrant { get; }
 
         /// <summary>
         /// Gets the URL to the application's terms of service.
         /// </summary>
-        Optional<string> TermsOfServiceURL { get; }
+        new Optional<string> TermsOfServiceURL { get; }
 
         /// <summary>
         /// Gets the URL to the application's privacy policy.
         /// </summary>
-        Optional<string> PrivacyPolicyURL { get; }
+        new Optional<string> PrivacyPolicyURL { get; }
 
         /// <summary>
         /// Gets the user information of the application owner.
         /// </summary>
-        IPartialUser? Owner { get; }
+        new IPartialUser? Owner { get; }
 
         /// <summary>
         /// Gets the summary of the game, if the application is a game sold on the Discord storefront.
         /// </summary>
-        string Summary { get; }
+        new string Summary { get; }
 
         /// <summary>
         /// Gets the hex-encoded key for GameSDK's GetTicket function.
         /// </summary>
-        string VerifyKey { get; }
+        new string VerifyKey { get; }
 
         /// <summary>
         /// Gets the team the application belongs to, if any.
         /// </summary>
-        ITeam? Team { get; }
+        new ITeam? Team { get; }
 
         /// <summary>
         /// Gets the guild the game is linked to, if the application is a game sold on the Discord storefront.
         /// </summary>
-        Optional<Snowflake> GuildID { get; }
+        new Optional<Snowflake> GuildID { get; }
 
         /// <summary>
         /// Gets the primary SKU ID of the game, if the application is a game sold on the Discord storefront.
         /// </summary>
-        Optional<Snowflake> PrimarySKUID { get; }
+        new Optional<Snowflake> PrimarySKUID { get; }
 
         /// <summary>
         /// Gets the URL slug that links to the store page, if the application is a game sold on the Discord storefront.
         /// </summary>
-        Optional<string> Slug { get; }
+        new Optional<string> Slug { get; }
 
         /// <summary>
         /// Gets the cover image, if the application is a game sold on the Discord storefront.
         /// </summary>
-        Optional<IImageHash> CoverImage { get; }
+        new Optional<IImageHash> CoverImage { get; }
 
         /// <summary>
         /// Gets the application's public flags.
         /// </summary>
-        Optional<ApplicationFlags> Flags { get; }
+        new Optional<ApplicationFlags> Flags { get; }
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialApplication.ID => this.ID;
+
+        /// <inheritdoc/>
+        Optional<string> IPartialApplication.Name => this.Name;
+
+        /// <inheritdoc/>
+        Optional<IImageHash?> IPartialApplication.Icon => new(this.Icon);
+
+        /// <inheritdoc/>
+        Optional<string> IPartialApplication.Description => this.Description;
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<string>> IPartialApplication.RPCOrigins => this.RPCOrigins;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialApplication.IsBotPublic => this.IsBotPublic;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialApplication.DoesBotRequireCodeGrant => this.DoesBotRequireCodeGrant;
+
+        /// <inheritdoc/>
+        Optional<string> IPartialApplication.TermsOfServiceURL => this.TermsOfServiceURL;
+
+        /// <inheritdoc/>
+        Optional<string> IPartialApplication.PrivacyPolicyURL => this.PrivacyPolicyURL;
+
+        /// <inheritdoc/>
+        Optional<IPartialUser?> IPartialApplication.Owner => new(this.Owner);
+
+        /// <inheritdoc/>
+        Optional<string> IPartialApplication.Summary => this.Summary;
+
+        /// <inheritdoc/>
+        Optional<string> IPartialApplication.VerifyKey => this.VerifyKey;
+
+        /// <inheritdoc/>
+        Optional<ITeam?> IPartialApplication.Team => new(this.Team);
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialApplication.GuildID => this.GuildID;
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialApplication.PrimarySKUID => this.PrimarySKUID;
+
+        /// <inheritdoc/>
+        Optional<string> IPartialApplication.Slug => this.Slug;
+
+        /// <inheritdoc/>
+        Optional<IImageHash> IPartialApplication.CoverImage => this.CoverImage;
+
+        /// <inheritdoc/>
+        Optional<ApplicationFlags> IPartialApplication.Flags => this.Flags;
     }
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Channels/IChannel.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Channels/IChannel.cs
@@ -31,139 +31,217 @@ namespace Remora.Discord.API.Abstractions.Objects
     /// Represents a channel.
     /// </summary>
     [PublicAPI]
-    public interface IChannel
+    public interface IChannel : IPartialChannel
     {
         /// <summary>
         /// Gets the ID of the channel.
         /// </summary>
-        Snowflake ID { get; }
+        new Snowflake ID { get; }
 
         /// <summary>
         /// Gets the type of the channel.
         /// </summary>
-        ChannelType Type { get; }
+        new ChannelType Type { get; }
 
         /// <summary>
         /// Gets the ID of the guild the channel is in.
         /// </summary>
-        Optional<Snowflake> GuildID { get; }
+        new Optional<Snowflake> GuildID { get; }
 
         /// <summary>
         /// Gets the sorting position of the channel.
         /// </summary>
-        Optional<int> Position { get; }
+        new Optional<int> Position { get; }
 
         /// <summary>
         /// Gets a list of explicit permission overwrites for members and roles.
         /// </summary>
-        Optional<IReadOnlyList<IPermissionOverwrite>> PermissionOverwrites { get; }
+        new Optional<IReadOnlyList<IPermissionOverwrite>> PermissionOverwrites { get; }
 
         /// <summary>
         /// Gets the name of the channel.
         /// </summary>
-        Optional<string> Name { get; }
+        new Optional<string> Name { get; }
 
         /// <summary>
         /// Gets the topic of the channel.
         /// </summary>
-        Optional<string?> Topic { get; }
+        new Optional<string?> Topic { get; }
 
         /// <summary>
         /// Gets a value indicating whether the channel is NSFW.
         /// </summary>
-        Optional<bool> IsNsfw { get; }
+        new Optional<bool> IsNsfw { get; }
 
         /// <summary>
         /// Gets the ID of the last message sent in the channel.
         /// </summary>
-        Optional<Snowflake?> LastMessageID { get; }
+        new Optional<Snowflake?> LastMessageID { get; }
 
         /// <summary>
         /// Gets the bitrate (in bits) of the channel.
         /// </summary>
-        Optional<int> Bitrate { get; }
+        new Optional<int> Bitrate { get; }
 
         /// <summary>
         /// Gets the user limit of the voice channel.
         /// </summary>
-        Optional<int> UserLimit { get; }
+        new Optional<int> UserLimit { get; }
 
         /// <summary>
         /// Gets the number of seconds a user has to wait before sending another message (0-21600); bots, as well as
         /// users with the permission <see cref="DiscordPermission.ManageMessages"/> or
         /// <see cref="DiscordPermission.ManageChannels"/> are unaffected. This is colloquially known as "slow mode".
         /// </summary>
-        Optional<TimeSpan> RateLimitPerUser { get; }
+        new Optional<TimeSpan> RateLimitPerUser { get; }
 
         /// <summary>
         /// Gets the recipients of the DM.
         /// </summary>
-        Optional<IReadOnlyList<IUser>> Recipients { get; }
+        new Optional<IReadOnlyList<IUser>> Recipients { get; }
 
         /// <summary>
         /// Gets the icon of the channel.
         /// </summary>
-        Optional<IImageHash?> Icon { get; }
+        new Optional<IImageHash?> Icon { get; }
 
         /// <summary>
         /// Gets the ID of the DM creator.
         /// </summary>
-        Optional<Snowflake> OwnerID { get; }
+        new Optional<Snowflake> OwnerID { get; }
 
         /// <summary>
         /// Gets the application ID of the group DM creator, if it is bot-created.
         /// </summary>
-        Optional<Snowflake> ApplicationID { get; }
+        new Optional<Snowflake> ApplicationID { get; }
 
         /// <summary>
         /// Gets the ID of the parent category for a channel. Each category can contain up to 50 channels.
         /// </summary>
-        Optional<Snowflake?> ParentID { get; }
+        new Optional<Snowflake?> ParentID { get; }
 
         /// <summary>
         /// Gets the time when the last pinned message was pinned.
         /// </summary>
-        Optional<DateTimeOffset?> LastPinTimestamp { get; }
+        new Optional<DateTimeOffset?> LastPinTimestamp { get; }
 
         /// <summary>
         /// Gets the ID of the voice channel region.
         /// </summary>
-        Optional<string?> RTCRegion { get; }
+        new Optional<string?> RTCRegion { get; }
 
         /// <summary>
         /// Gets the video quality mode of the channel.
         /// </summary>
-        Optional<VideoQualityMode> VideoQualityMode { get; }
+        new Optional<VideoQualityMode> VideoQualityMode { get; }
 
         /// <summary>
         /// Gets an approximate count of the messages in the channel. Stops counting at 50.
         /// </summary>
-        Optional<int> MessageCount { get; }
+        new Optional<int> MessageCount { get; }
 
         /// <summary>
         /// Gets an approximate count of the messages in the channel. Stops counting at 50.
         /// </summary>
-        Optional<int> MemberCount { get; }
+        new Optional<int> MemberCount { get; }
 
         /// <summary>
         /// Gets a set of thread-specific fields.
         /// </summary>
-        Optional<IThreadMetadata> ThreadMetadata { get; }
+        new Optional<IThreadMetadata> ThreadMetadata { get; }
 
         /// <summary>
         /// Gets the thread member object for the current user, if they have joined the thread.
         /// </summary>
-        Optional<IThreadMember> Member { get; }
+        new Optional<IThreadMember> Member { get; }
 
         /// <summary>
         /// Gets the default duration for newly created threads in this channel.
         /// </summary>
-        Optional<AutoArchiveDuration> DefaultAutoArchiveDuration { get; }
+        new Optional<AutoArchiveDuration> DefaultAutoArchiveDuration { get; }
 
         /// <summary>
         /// Gets the computed permission set for the invoking user in the channel. Typically present when the channel is
         /// resolved via a slash command interaction.
         /// </summary>
-        Optional<IDiscordPermissionSet> Permissions { get; }
+        new Optional<IDiscordPermissionSet> Permissions { get; }
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialChannel.ID => this.ID;
+
+        /// <inheritdoc/>
+        Optional<ChannelType> IPartialChannel.Type => this.Type;
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialChannel.GuildID => this.GuildID;
+
+        /// <inheritdoc/>
+        Optional<int> IPartialChannel.Position => this.Position;
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<IPermissionOverwrite>> IPartialChannel.PermissionOverwrites => this.PermissionOverwrites;
+
+        /// <inheritdoc/>
+        Optional<string> IPartialChannel.Name => this.Name;
+
+        /// <inheritdoc/>
+        Optional<string?> IPartialChannel.Topic => this.Topic;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialChannel.IsNsfw => this.IsNsfw;
+
+        /// <inheritdoc/>
+        Optional<Snowflake?> IPartialChannel.LastMessageID => this.LastMessageID;
+
+        /// <inheritdoc/>
+        Optional<int> IPartialChannel.Bitrate => this.Bitrate;
+
+        /// <inheritdoc/>
+        Optional<int> IPartialChannel.UserLimit => this.UserLimit;
+
+        /// <inheritdoc/>
+        Optional<TimeSpan> IPartialChannel.RateLimitPerUser => this.RateLimitPerUser;
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<IUser>> IPartialChannel.Recipients => this.Recipients;
+
+        /// <inheritdoc/>
+        Optional<IImageHash?> IPartialChannel.Icon => this.Icon;
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialChannel.OwnerID => this.OwnerID;
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialChannel.ApplicationID => this.ApplicationID;
+
+        /// <inheritdoc/>
+        Optional<Snowflake?> IPartialChannel.ParentID => this.ParentID;
+
+        /// <inheritdoc/>
+        Optional<DateTimeOffset?> IPartialChannel.LastPinTimestamp => this.LastPinTimestamp;
+
+        /// <inheritdoc/>
+        Optional<string?> IPartialChannel.RTCRegion => this.RTCRegion;
+
+        /// <inheritdoc/>
+        Optional<VideoQualityMode> IPartialChannel.VideoQualityMode => this.VideoQualityMode;
+
+        /// <inheritdoc/>
+        Optional<int> IPartialChannel.MessageCount => this.MessageCount;
+
+        /// <inheritdoc/>
+        Optional<int> IPartialChannel.MemberCount => this.MemberCount;
+
+        /// <inheritdoc/>
+        Optional<IThreadMetadata> IPartialChannel.ThreadMetadata => this.ThreadMetadata;
+
+        /// <inheritdoc/>
+        Optional<IThreadMember> IPartialChannel.Member => this.Member;
+
+        /// <inheritdoc/>
+        Optional<AutoArchiveDuration> IPartialChannel.DefaultAutoArchiveDuration => this.DefaultAutoArchiveDuration;
+
+        /// <inheritdoc/>
+        Optional<IDiscordPermissionSet> IPartialChannel.Permissions => this.Permissions;
     }
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Emojis/IEmoji.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Emojis/IEmoji.cs
@@ -30,46 +30,70 @@ namespace Remora.Discord.API.Abstractions.Objects
     /// Represents an emoji.
     /// </summary>
     [PublicAPI]
-    public interface IEmoji
+    public interface IEmoji : IPartialEmoji
     {
         /// <summary>
         /// Gets the ID of the emoji.
         /// </summary>
-        Snowflake? ID { get; }
+        new Snowflake? ID { get; }
 
         /// <summary>
         /// Gets the name of the emoji.
         /// </summary>
-        string? Name { get; }
+        new string? Name { get; }
 
         /// <summary>
         /// Gets a list of roles this emoji is whitelisted to.
         /// </summary>
-        Optional<IReadOnlyList<Snowflake>> Roles { get; }
+        new Optional<IReadOnlyList<Snowflake>> Roles { get; }
 
         /// <summary>
         /// Gets the user that created this emoji.
         /// </summary>
-        Optional<IUser> User { get; }
+        new Optional<IUser> User { get; }
 
         /// <summary>
         /// Gets a value indicating whether this emoji must be wrapped in colons.
         /// </summary>
-        Optional<bool> RequireColons { get; }
+        new Optional<bool> RequireColons { get; }
 
         /// <summary>
         /// Gets a value indicating whether this emoji is managed.
         /// </summary>
-        Optional<bool> IsManaged { get; }
+        new Optional<bool> IsManaged { get; }
 
         /// <summary>
         /// Gets a value indicating whether this emoji is animated.
         /// </summary>
-        Optional<bool> IsAnimated { get; }
+        new Optional<bool> IsAnimated { get; }
 
         /// <summary>
         /// Gets a value indicating whether this emoji is available. May be false due to a loss of server boosts.
         /// </summary>
-        Optional<bool> IsAvailable { get; }
+        new Optional<bool> IsAvailable { get; }
+
+        /// <inheritdoc/>
+        Optional<Snowflake?> IPartialEmoji.ID => this.ID;
+
+        /// <inheritdoc/>
+        Optional<string?> IPartialEmoji.Name => this.Name;
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<Snowflake>> IPartialEmoji.Roles => this.Roles;
+
+        /// <inheritdoc/>
+        Optional<IUser> IPartialEmoji.User => this.User;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialEmoji.RequireColons => this.RequireColons;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialEmoji.IsManaged => this.IsManaged;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialEmoji.IsAnimated => this.IsAnimated;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialEmoji.IsAvailable => this.IsAvailable;
     }
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Guilds/IGuild.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Guilds/IGuild.cs
@@ -282,13 +282,13 @@ namespace Remora.Discord.API.Abstractions.Objects
         Optional<string> IPartialGuild.Name => this.Name;
 
         /// <inheritdoc/>
-        Optional<IImageHash?> IPartialGuild.Icon => throw new NotImplementedException();
+        Optional<IImageHash?> IPartialGuild.Icon => new(this.Icon);
 
         /// <inheritdoc/>
-        Optional<IImageHash?> IPartialGuild.Splash => throw new NotImplementedException();
+        Optional<IImageHash?> IPartialGuild.Splash => new(this.Splash);
 
         /// <inheritdoc/>
-        Optional<IImageHash?> IPartialGuild.DiscoverySplash => throw new NotImplementedException();
+        Optional<IImageHash?> IPartialGuild.DiscoverySplash => new(this.DiscoverySplash);
 
         /// <inheritdoc/>
         Optional<bool> IPartialGuild.IsOwner => this.IsOwner;
@@ -315,13 +315,13 @@ namespace Remora.Discord.API.Abstractions.Objects
         Optional<ExplicitContentFilterLevel> IPartialGuild.ExplicitContentFilter => this.ExplicitContentFilter;
 
         /// <inheritdoc/>
-        Optional<IReadOnlyList<IRole>> IPartialGuild.Roles => throw new NotImplementedException();
+        Optional<IReadOnlyList<IRole>> IPartialGuild.Roles => new(this.Roles);
 
         /// <inheritdoc/>
-        Optional<IReadOnlyList<IEmoji>> IPartialGuild.Emojis => throw new NotImplementedException();
+        Optional<IReadOnlyList<IEmoji>> IPartialGuild.Emojis => new(this.Emojis);
 
         /// <inheritdoc/>
-        Optional<IReadOnlyList<GuildFeature>> IPartialGuild.GuildFeatures => throw new NotImplementedException();
+        Optional<IReadOnlyList<GuildFeature>> IPartialGuild.GuildFeatures => new(this.GuildFeatures);
 
         /// <inheritdoc/>
         Optional<MultiFactorAuthenticationLevel> IPartialGuild.MFALevel => this.MFALevel;
@@ -384,7 +384,7 @@ namespace Remora.Discord.API.Abstractions.Objects
         Optional<string?> IPartialGuild.Description => this.Description;
 
         /// <inheritdoc/>
-        Optional<IImageHash?> IPartialGuild.Banner => throw new NotImplementedException();
+        Optional<IImageHash?> IPartialGuild.Banner => new(this.Banner);
 
         /// <inheritdoc/>
         Optional<PremiumTier> IPartialGuild.PremiumTier => this.PremiumTier;

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Guilds/IGuild.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Guilds/IGuild.cs
@@ -31,248 +31,392 @@ namespace Remora.Discord.API.Abstractions.Objects
     /// Represents a Discord Guild.
     /// </summary>
     [PublicAPI]
-    public interface IGuild
+    public interface IGuild : IPartialGuild
     {
         /// <summary>
         /// Gets the ID of the guild.
         /// </summary>
-        Snowflake ID { get; }
+        new Snowflake ID { get; }
 
         /// <summary>
         /// Gets the name of the guild.
         /// </summary>
-        string Name { get; }
+        new string Name { get; }
 
         /// <summary>
         /// Gets the guild's icon.
         /// </summary>
-        IImageHash? Icon { get; }
+        new IImageHash? Icon { get; }
 
         /// <summary>
         /// Gets the guild's splash banner.
         /// </summary>
-        IImageHash? Splash { get; }
+        new IImageHash? Splash { get; }
 
         /// <summary>
         /// Gets the guild's Discovery splash banner.
         /// </summary>
-        IImageHash? DiscoverySplash { get; }
+        new IImageHash? DiscoverySplash { get; }
 
         /// <summary>
         /// Gets a value indicating whether the current user is the guild's owner.
         /// </summary>
-        Optional<bool> IsOwner { get; }
+        new Optional<bool> IsOwner { get; }
 
         /// <summary>
         /// Gets the ID of the owner.
         /// </summary>
-        Snowflake OwnerID { get; }
+        new Snowflake OwnerID { get; }
 
         /// <summary>
         /// Gets the permissions for the current user in the guild.
         /// </summary>
-        Optional<IDiscordPermissionSet> Permissions { get; }
+        new Optional<IDiscordPermissionSet> Permissions { get; }
 
         /// <summary>
         /// Gets the ID of the AFK channel.
         /// </summary>
-        Snowflake? AFKChannelID { get; }
+        new Snowflake? AFKChannelID { get; }
 
         /// <summary>
         /// Gets the AFK timeout (in seconds).
         /// </summary>
-        TimeSpan AFKTimeout { get; }
+        new TimeSpan AFKTimeout { get; }
 
         /// <summary>
         /// Gets the verification level required for the guild.
         /// </summary>
-        VerificationLevel VerificationLevel { get; }
+        new VerificationLevel VerificationLevel { get; }
 
         /// <summary>
         /// Gets the default notification level for the guild.
         /// </summary>
-        MessageNotificationLevel DefaultMessageNotifications { get; }
+        new MessageNotificationLevel DefaultMessageNotifications { get; }
 
         /// <summary>
         /// Gets the explicit content level.
         /// </summary>
-        ExplicitContentFilterLevel ExplicitContentFilter { get; }
+        new ExplicitContentFilterLevel ExplicitContentFilter { get; }
 
         /// <summary>
         /// Gets a list of the roles in the server.
         /// </summary>
-        IReadOnlyList<IRole> Roles { get; }
+        new IReadOnlyList<IRole> Roles { get; }
 
         /// <summary>
         /// Gets a list of emojis in the server.
         /// </summary>
-        IReadOnlyList<IEmoji> Emojis { get; }
+        new IReadOnlyList<IEmoji> Emojis { get; }
 
         /// <summary>
         /// Gets a list of guild features.
         /// </summary>
-        IReadOnlyList<GuildFeature> GuildFeatures { get; }
+        new IReadOnlyList<GuildFeature> GuildFeatures { get; }
 
         /// <summary>
         /// Gets the required MFA level for the guild.
         /// </summary>
-        MultiFactorAuthenticationLevel MFALevel { get; }
+        new MultiFactorAuthenticationLevel MFALevel { get; }
 
         /// <summary>
         /// Gets the application ID of the guild creator if it is bot-created.
         /// </summary>
-        Snowflake? ApplicationID { get; }
+        new Snowflake? ApplicationID { get; }
 
         /// <summary>
         /// Gets a value indicating whether the server widget is enabled.
         /// </summary>
-        Optional<bool> IsWidgetEnabled { get; }
+        new Optional<bool> IsWidgetEnabled { get; }
 
         /// <summary>
         /// Gets the ID of the channel the widget generates invites to.
         /// </summary>
-        Optional<Snowflake?> WidgetChannelID { get; }
+        new Optional<Snowflake?> WidgetChannelID { get; }
 
         /// <summary>
         /// Gets the ID of the channel that system messages are sent to.
         /// </summary>
-        Snowflake? SystemChannelID { get; }
+        new Snowflake? SystemChannelID { get; }
 
         /// <summary>
         /// Gets the flags on the system channel.
         /// </summary>
-        SystemChannelFlags SystemChannelFlags { get; }
+        new SystemChannelFlags SystemChannelFlags { get; }
 
         /// <summary>
         /// Gets the ID of the rules channel, if any. This is the channel where community-enabled guilds can display
         /// rules and/or guidelines.
         /// </summary>
-        Snowflake? RulesChannelID { get; }
+        new Snowflake? RulesChannelID { get; }
 
         /// <summary>
         /// Gets the time when the current user joined the guild.
         /// </summary>
-        Optional<DateTimeOffset> JoinedAt { get; }
+        new Optional<DateTimeOffset> JoinedAt { get; }
 
         /// <summary>
         /// Gets a value indicating whether this is considered a large guild.
         /// </summary>
-        Optional<bool> IsLarge { get; }
+        new Optional<bool> IsLarge { get; }
 
         /// <summary>
         /// Gets a value indicating whether the guild is unavailable due to an outage.
         /// </summary>
-        Optional<bool> IsUnavailable { get; }
+        new Optional<bool> IsUnavailable { get; }
 
         /// <summary>
         /// Gets the number of members in the guild.
         /// </summary>
-        Optional<int> MemberCount { get; }
+        new Optional<int> MemberCount { get; }
 
         /// <summary>
         /// Gets the states of members currently in voice channels.
         /// </summary>
-        Optional<IReadOnlyList<IPartialVoiceState>> VoiceStates { get; }
+        new Optional<IReadOnlyList<IPartialVoiceState>> VoiceStates { get; }
 
         /// <summary>
         /// Gets the members in the guild.
         /// </summary>
-        Optional<IReadOnlyList<IGuildMember>> Members { get; }
+        new Optional<IReadOnlyList<IGuildMember>> Members { get; }
 
         /// <summary>
         /// Gets the channels in the guild.
         /// </summary>
-        Optional<IReadOnlyList<IChannel>> Channels { get; }
+        new Optional<IReadOnlyList<IChannel>> Channels { get; }
 
         /// <summary>
         /// Gets the threads in the guild.
         /// </summary>
-        Optional<IReadOnlyList<IChannel>> Threads { get; }
+        new Optional<IReadOnlyList<IChannel>> Threads { get; }
 
         /// <summary>
         /// Gets the presences of the members in the guild.
         /// </summary>
-        Optional<IReadOnlyList<IPartialPresence>> Presences { get; }
+        new Optional<IReadOnlyList<IPartialPresence>> Presences { get; }
 
         /// <summary>
         /// Gets the maximum number of presences for the guild. This is null for all but the largest of guilds.
         /// </summary>
-        Optional<int?> MaxPresences { get; }
+        new Optional<int?> MaxPresences { get; }
 
         /// <summary>
         /// Gets the maximum number of members for the guild.
         /// </summary>
-        Optional<int> MaxMembers { get; }
+        new Optional<int> MaxMembers { get; }
 
         /// <summary>
         /// Gets the vanity url code for the guild.
         /// </summary>
-        string? VanityUrlCode { get; }
+        new string? VanityUrlCode { get; }
 
         /// <summary>
         /// Gets the description of the guild, if the guild is discoverable.
         /// </summary>
-        string? Description { get; }
+        new string? Description { get; }
 
         /// <summary>
         /// Gets the hash of the guild banner.
         /// </summary>
-        IImageHash? Banner { get; }
+        new IImageHash? Banner { get; }
 
         /// <summary>
         /// Gets the boost level of the guild.
         /// </summary>
-        PremiumTier PremiumTier { get; }
+        new PremiumTier PremiumTier { get; }
 
         /// <summary>
         /// Gets the number of boosts the guild currently has.
         /// </summary>
-        Optional<int> PremiumSubscriptionCount { get; }
+        new Optional<int> PremiumSubscriptionCount { get; }
 
         /// <summary>
         /// Gets the preferred locale of a public-enabled guild.
         /// </summary>
-        string PreferredLocale { get; }
+        new string PreferredLocale { get; }
 
         /// <summary>
         /// Gets the ID of the channel where admins and moderators of community-enabled guilds receive notices from
         /// Discord.
         /// </summary>
-        Snowflake? PublicUpdatesChannelID { get; }
+        new Snowflake? PublicUpdatesChannelID { get; }
 
         /// <summary>
         /// Gets the maximum number of users in a video channel.
         /// </summary>
-        Optional<int> MaxVideoChannelUsers { get; }
+        new Optional<int> MaxVideoChannelUsers { get; }
 
         /// <summary>
         /// Gets the approximate number of members in the guild.
         /// </summary>
-        Optional<int> ApproximateMemberCount { get; }
+        new Optional<int> ApproximateMemberCount { get; }
 
         /// <summary>
         /// Gets the approximate number of non-offline members in the guild.
         /// </summary>
-        Optional<int> ApproximatePresenceCount { get; }
+        new Optional<int> ApproximatePresenceCount { get; }
 
         /// <summary>
         /// Gets the welcome screen shown to new members.
         /// </summary>
-        Optional<IWelcomeScreen> WelcomeScreen { get; }
+        new Optional<IWelcomeScreen> WelcomeScreen { get; }
 
         /// <summary>
         /// Gets the guild's NSFW level.
         /// </summary>
-        GuildNSFWLevel NSFWLevel { get; }
+        new GuildNSFWLevel NSFWLevel { get; }
 
         /// <summary>
         /// Gets the stage instances in the guild.
         /// </summary>
-        Optional<IReadOnlyList<IStageInstance>> StageInstances { get; }
+        new Optional<IReadOnlyList<IStageInstance>> StageInstances { get; }
 
         /// <summary>
         /// Gets the stickers in the guild.
         /// </summary>
-        Optional<IReadOnlyList<ISticker>> Stickers { get; }
+        new Optional<IReadOnlyList<ISticker>> Stickers { get; }
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialGuild.ID => this.ID;
+
+        /// <inheritdoc/>
+        Optional<string> IPartialGuild.Name => this.Name;
+
+        /// <inheritdoc/>
+        Optional<IImageHash?> IPartialGuild.Icon => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        Optional<IImageHash?> IPartialGuild.Splash => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        Optional<IImageHash?> IPartialGuild.DiscoverySplash => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialGuild.IsOwner => this.IsOwner;
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialGuild.OwnerID => this.OwnerID;
+
+        /// <inheritdoc/>
+        Optional<IDiscordPermissionSet> IPartialGuild.Permissions => this.Permissions;
+
+        /// <inheritdoc/>
+        Optional<Snowflake?> IPartialGuild.AFKChannelID => this.AFKChannelID;
+
+        /// <inheritdoc/>
+        Optional<TimeSpan> IPartialGuild.AFKTimeout => this.AFKTimeout;
+
+        /// <inheritdoc/>
+        Optional<VerificationLevel> IPartialGuild.VerificationLevel => this.VerificationLevel;
+
+        /// <inheritdoc/>
+        Optional<MessageNotificationLevel> IPartialGuild.DefaultMessageNotifications => this.DefaultMessageNotifications;
+
+        /// <inheritdoc/>
+        Optional<ExplicitContentFilterLevel> IPartialGuild.ExplicitContentFilter => this.ExplicitContentFilter;
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<IRole>> IPartialGuild.Roles => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<IEmoji>> IPartialGuild.Emojis => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<GuildFeature>> IPartialGuild.GuildFeatures => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        Optional<MultiFactorAuthenticationLevel> IPartialGuild.MFALevel => this.MFALevel;
+
+        /// <inheritdoc/>
+        Optional<Snowflake?> IPartialGuild.ApplicationID => this.ApplicationID;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialGuild.IsWidgetEnabled => this.IsWidgetEnabled;
+
+        /// <inheritdoc/>
+        Optional<Snowflake?> IPartialGuild.WidgetChannelID => this.WidgetChannelID;
+
+        /// <inheritdoc/>
+        Optional<Snowflake?> IPartialGuild.SystemChannelID => this.SystemChannelID;
+
+        /// <inheritdoc/>
+        Optional<SystemChannelFlags> IPartialGuild.SystemChannelFlags => this.SystemChannelFlags;
+
+        /// <inheritdoc/>
+        Optional<Snowflake?> IPartialGuild.RulesChannelID => this.RulesChannelID;
+
+        /// <inheritdoc/>
+        Optional<DateTimeOffset> IPartialGuild.JoinedAt => this.JoinedAt;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialGuild.IsLarge => this.IsLarge;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialGuild.IsUnavailable => this.IsUnavailable;
+
+        /// <inheritdoc/>
+        Optional<int> IPartialGuild.MemberCount => this.MemberCount;
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<IPartialVoiceState>> IPartialGuild.VoiceStates => this.VoiceStates;
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<IGuildMember>> IPartialGuild.Members => this.Members;
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<IChannel>> IPartialGuild.Channels => this.Channels;
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<IChannel>> IPartialGuild.Threads => this.Threads;
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<IPartialPresence>> IPartialGuild.Presences => this.Presences;
+
+        /// <inheritdoc/>
+        Optional<int?> IPartialGuild.MaxPresences => this.MaxPresences;
+
+        /// <inheritdoc/>
+        Optional<int> IPartialGuild.MaxMembers => this.MaxMembers;
+
+        /// <inheritdoc/>
+        Optional<string?> IPartialGuild.VanityUrlCode => this.VanityUrlCode;
+
+        /// <inheritdoc/>
+        Optional<string?> IPartialGuild.Description => this.Description;
+
+        /// <inheritdoc/>
+        Optional<IImageHash?> IPartialGuild.Banner => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        Optional<PremiumTier> IPartialGuild.PremiumTier => this.PremiumTier;
+
+        /// <inheritdoc/>
+        Optional<int> IPartialGuild.PremiumSubscriptionCount => this.PremiumSubscriptionCount;
+
+        /// <inheritdoc/>
+        Optional<string> IPartialGuild.PreferredLocale => this.PreferredLocale;
+
+        /// <inheritdoc/>
+        Optional<Snowflake?> IPartialGuild.PublicUpdatesChannelID => this.PublicUpdatesChannelID;
+
+        /// <inheritdoc/>
+        Optional<int> IPartialGuild.MaxVideoChannelUsers => this.MaxVideoChannelUsers;
+
+        /// <inheritdoc/>
+        Optional<int> IPartialGuild.ApproximateMemberCount => this.ApproximateMemberCount;
+
+        /// <inheritdoc/>
+        Optional<int> IPartialGuild.ApproximatePresenceCount => this.ApproximatePresenceCount;
+
+        /// <inheritdoc/>
+        Optional<IWelcomeScreen> IPartialGuild.WelcomeScreen => this.WelcomeScreen;
+
+        /// <inheritdoc/>
+        Optional<GuildNSFWLevel> IPartialGuild.NSFWLevel => this.NSFWLevel;
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<IStageInstance>> IPartialGuild.StageInstances => this.StageInstances;
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<ISticker>> IPartialGuild.Stickers => this.Stickers;
     }
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Guilds/IGuildMember.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Guilds/IGuildMember.cs
@@ -31,51 +31,78 @@ namespace Remora.Discord.API.Abstractions.Objects
     /// Represents information about a guild member.
     /// </summary>
     [PublicAPI]
-    public interface IGuildMember
+    public interface IGuildMember : IPartialGuildMember
     {
         /// <summary>
         /// Gets the user this guild member represents.
         /// </summary>
-        Optional<IUser> User { get; }
+        new Optional<IUser> User { get; }
 
         /// <summary>
         /// Gets the user's guild nickname.
         /// </summary>
-        Optional<string?> Nickname { get; }
+        new Optional<string?> Nickname { get; }
 
         /// <summary>
         /// Gets the roles the user has.
         /// </summary>
-        IReadOnlyList<Snowflake> Roles { get; }
+        new IReadOnlyList<Snowflake> Roles { get; }
 
         /// <summary>
         /// Gets when the user joined the guild.
         /// </summary>
-        DateTimeOffset JoinedAt { get; }
+        new DateTimeOffset JoinedAt { get; }
 
         /// <summary>
         /// Gets when the user started boosting the guild.
         /// </summary>
-        Optional<DateTimeOffset?> PremiumSince { get; }
+        new Optional<DateTimeOffset?> PremiumSince { get; }
 
         /// <summary>
         /// Gets a value indicating whether the user is deafened in voice channels.
         /// </summary>
-        bool IsDeafened { get; }
+        new bool IsDeafened { get; }
 
         /// <summary>
         /// Gets a value indicating whether the user is muted in voice channels.
         /// </summary>
-        bool IsMuted { get; }
+        new bool IsMuted { get; }
 
         /// <summary>
         /// Gets a value indicating whether the user has passed the guild membership screening requirements.
         /// </summary>
-        Optional<bool?> IsPending { get; }
+        new Optional<bool?> IsPending { get; }
 
         /// <summary>
         /// Gets the total permissions of the member in a channel, including overrides.
         /// </summary>
-        Optional<IDiscordPermissionSet> Permissions { get; }
+        new Optional<IDiscordPermissionSet> Permissions { get; }
+
+        /// <inheritdoc/>
+        Optional<IUser> IPartialGuildMember.User => this.User;
+
+        /// <inheritdoc/>
+        Optional<string?> IPartialGuildMember.Nickname => this.Nickname;
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<Snowflake>> IPartialGuildMember.Roles => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        Optional<DateTimeOffset> IPartialGuildMember.JoinedAt => this.JoinedAt;
+
+        /// <inheritdoc/>
+        Optional<DateTimeOffset?> IPartialGuildMember.PremiumSince => this.PremiumSince;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialGuildMember.IsDeafened => this.IsDeafened;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialGuildMember.IsMuted => this.IsMuted;
+
+        /// <inheritdoc/>
+        Optional<bool?> IPartialGuildMember.IsPending => this.IsPending;
+
+        /// <inheritdoc/>
+        Optional<IDiscordPermissionSet> IPartialGuildMember.Permissions => this.Permissions;
     }
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Guilds/IGuildMember.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Guilds/IGuildMember.cs
@@ -85,7 +85,7 @@ namespace Remora.Discord.API.Abstractions.Objects
         Optional<string?> IPartialGuildMember.Nickname => this.Nickname;
 
         /// <inheritdoc/>
-        Optional<IReadOnlyList<Snowflake>> IPartialGuildMember.Roles => throw new NotImplementedException();
+        Optional<IReadOnlyList<Snowflake>> IPartialGuildMember.Roles => new(this.Roles);
 
         /// <inheritdoc/>
         Optional<DateTimeOffset> IPartialGuildMember.JoinedAt => this.JoinedAt;

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Integrations/IIntegration.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Integrations/IIntegration.cs
@@ -30,81 +30,126 @@ namespace Remora.Discord.API.Abstractions.Objects
     /// Represents an integration object.
     /// </summary>
     [PublicAPI]
-    public interface IIntegration
+    public interface IIntegration : IPartialIntegration
     {
         /// <summary>
         /// Gets the ID of the integration.
         /// </summary>
-        Snowflake ID { get; }
+        new Snowflake ID { get; }
 
         /// <summary>
         /// Gets the name of the integration.
         /// </summary>
-        string Name { get; }
+        new string Name { get; }
 
         /// <summary>
         /// Gets the type of integration.
         /// </summary>
-        string Type { get; }
+        new string Type { get; }
 
         /// <summary>
         /// Gets a value indicating whether the integration is enabled.
         /// </summary>
-        bool IsEnabled { get; }
+        new bool IsEnabled { get; }
 
         /// <summary>
         /// Gets a value indicating whether the integration is syncing.
         /// </summary>
-        bool IsSyncing { get; }
+        new bool IsSyncing { get; }
 
         /// <summary>
         /// Gets the ID of the role that this integration uses for subscribers.
         /// </summary>
-        Snowflake RoleID { get; }
+        new Snowflake RoleID { get; }
 
         /// <summary>
         /// Gets a value indicating whether emoticons should be synced for this integration (twitch only, currently).
         /// </summary>
-        Optional<bool> EnableEmoticons { get; }
+        new Optional<bool> EnableEmoticons { get; }
 
         /// <summary>
         /// Gets the behaviour of expiring subscribers.
         /// </summary>
-        IntegrationExpireBehaviour ExpireBehaviour { get; }
+        new IntegrationExpireBehaviour ExpireBehaviour { get; }
 
         /// <summary>
         /// Gets the grace period (in days) before expiring subscribers.
         /// </summary>
-        TimeSpan ExpireGracePeriod { get; }
+        new TimeSpan ExpireGracePeriod { get; }
 
         /// <summary>
         /// Gets the user for this integration.
         /// </summary>
-        Optional<IUser> User { get; }
+        new Optional<IUser> User { get; }
 
         /// <summary>
         /// Gets the integration's account information.
         /// </summary>
-        IAccount Account { get; }
+        new IAccount Account { get; }
 
         /// <summary>
         /// Gets the time when the integration was last synced.
         /// </summary>
-        DateTimeOffset SyncedAt { get; }
+        new DateTimeOffset SyncedAt { get; }
 
         /// <summary>
         /// Gets the number of subscribers this integration has.
         /// </summary>
-        int SubscriberCount { get; }
+        new int SubscriberCount { get; }
 
         /// <summary>
         /// Gets a value indicating whether this integration has been revoked.
         /// </summary>
-        bool IsRevoked { get; }
+        new bool IsRevoked { get; }
 
         /// <summary>
         /// Gets the bot/OAuth2 application for Discord integrations.
         /// </summary>
-        Optional<IIntegrationApplication> Application { get; }
+        new Optional<IIntegrationApplication> Application { get; }
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialIntegration.ID => this.ID;
+
+        /// <inheritdoc/>
+        Optional<string> IPartialIntegration.Name => this.Name;
+
+        /// <inheritdoc/>
+        Optional<string> IPartialIntegration.Type => this.Type;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialIntegration.IsEnabled => this.IsEnabled;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialIntegration.IsSyncing => this.IsSyncing;
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialIntegration.RoleID => this.RoleID;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialIntegration.EnableEmoticons => this.EnableEmoticons;
+
+        /// <inheritdoc/>
+        Optional<IntegrationExpireBehaviour> IPartialIntegration.ExpireBehaviour => this.ExpireBehaviour;
+
+        /// <inheritdoc/>
+        Optional<TimeSpan> IPartialIntegration.ExpireGracePeriod => this.ExpireGracePeriod;
+
+        /// <inheritdoc/>
+        Optional<IUser> IPartialIntegration.User => this.User;
+
+        /// <inheritdoc/>
+        Optional<IAccount> IPartialIntegration.Account => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        Optional<DateTimeOffset> IPartialIntegration.SyncedAt => this.SyncedAt;
+
+        /// <inheritdoc/>
+        Optional<int> IPartialIntegration.SubscriberCount => this.SubscriberCount;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialIntegration.IsRevoked => this.IsRevoked;
+
+        /// <inheritdoc/>
+        Optional<IIntegrationApplication> IPartialIntegration.Application => this.Application;
     }
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Integrations/IIntegration.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Integrations/IIntegration.cs
@@ -138,7 +138,7 @@ namespace Remora.Discord.API.Abstractions.Objects
         Optional<IUser> IPartialIntegration.User => this.User;
 
         /// <inheritdoc/>
-        Optional<IAccount> IPartialIntegration.Account => throw new NotImplementedException();
+        Optional<IAccount> IPartialIntegration.Account => new(this.Account);
 
         /// <inheritdoc/>
         Optional<DateTimeOffset> IPartialIntegration.SyncedAt => this.SyncedAt;

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/IGuildApplicationCommandPermissions.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/IGuildApplicationCommandPermissions.cs
@@ -30,26 +30,38 @@ namespace Remora.Discord.API.Abstractions.Objects
     /// Represents a set of permissions for a command in a guild.
     /// </summary>
     [PublicAPI]
-    public interface IGuildApplicationCommandPermissions
+    public interface IGuildApplicationCommandPermissions : IPartialGuildApplicationCommandPermissions
     {
         /// <summary>
         /// Gets the ID of the command.
         /// </summary>
-        Snowflake ID { get; }
+        new Snowflake ID { get; }
 
         /// <summary>
         /// Gets the ID of the application the command belongs to.
         /// </summary>
-        Snowflake ApplicationID { get; }
+        new Snowflake ApplicationID { get; }
 
         /// <summary>
         /// Gets the ID of the guild.
         /// </summary>
-        Snowflake GuildID { get; }
+        new Snowflake GuildID { get; }
 
         /// <summary>
         /// Gets the permissions for the command in the guild.
         /// </summary>
-        IReadOnlyList<IApplicationCommandPermissions> Permissions { get; }
+        new IReadOnlyList<IApplicationCommandPermissions> Permissions { get; }
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialGuildApplicationCommandPermissions.ID => this.ID;
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialGuildApplicationCommandPermissions.ApplicationID => this.ApplicationID;
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialGuildApplicationCommandPermissions.GuildID => this.GuildID;
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<IApplicationCommandPermissions>> IPartialGuildApplicationCommandPermissions.Permissions => throw new System.NotImplementedException();
     }
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/IGuildApplicationCommandPermissions.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/IGuildApplicationCommandPermissions.cs
@@ -62,6 +62,7 @@ namespace Remora.Discord.API.Abstractions.Objects
         Optional<Snowflake> IPartialGuildApplicationCommandPermissions.GuildID => this.GuildID;
 
         /// <inheritdoc/>
-        Optional<IReadOnlyList<IApplicationCommandPermissions>> IPartialGuildApplicationCommandPermissions.Permissions => throw new System.NotImplementedException();
+        Optional<IReadOnlyList<IApplicationCommandPermissions>> IPartialGuildApplicationCommandPermissions.Permissions
+            => new(this.Permissions);
     }
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Invites/IInvite.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Invites/IInvite.cs
@@ -94,7 +94,7 @@ namespace Remora.Discord.API.Abstractions.Objects
         Optional<IPartialGuild> IPartialInvite.Guild => this.Guild;
 
         /// <inheritdoc/>
-        Optional<IPartialChannel> IPartialInvite.Channel => throw new NotImplementedException();
+        Optional<IPartialChannel> IPartialInvite.Channel => new(this.Channel);
 
         /// <inheritdoc/>
         Optional<IUser> IPartialInvite.Inviter => this.Inviter;

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Invites/IInvite.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Invites/IInvite.cs
@@ -30,61 +30,94 @@ namespace Remora.Discord.API.Abstractions.Objects
     /// Represents an invite.
     /// </summary>
     [PublicAPI]
-    public interface IInvite
+    public interface IInvite : IPartialInvite
     {
         /// <summary>
         /// Gets the unique invite code.
         /// </summary>
-        string Code { get; }
+        new string Code { get; }
 
         /// <summary>
         /// Gets the guild this invite is for.
         /// </summary>
-        Optional<IPartialGuild> Guild { get; }
+        new Optional<IPartialGuild> Guild { get; }
 
         /// <summary>
         /// Gets the channel this invite is for.
         /// </summary>
-        IPartialChannel Channel { get; }
+        new IPartialChannel Channel { get; }
 
         /// <summary>
         /// Gets the user who created the invite.
         /// </summary>
-        Optional<IUser> Inviter { get; }
+        new Optional<IUser> Inviter { get; }
 
         /// <summary>
         /// Gets the type of target for this invite.
         /// </summary>
-        Optional<InviteTarget> TargetType { get; }
+        new Optional<InviteTarget> TargetType { get; }
 
         /// <summary>
         /// Gets the target user for this invite.
         /// </summary>
-        Optional<IPartialUser> TargetUser { get; }
+        new Optional<IPartialUser> TargetUser { get; }
 
         /// <summary>
         /// Gets the ID of the target embedded application.
         /// </summary>
-        Optional<Snowflake> TargetApplication { get; }
+        new Optional<Snowflake> TargetApplication { get; }
 
         /// <summary>
         /// Gets the approximate count of online members. Only present when <see cref="TargetUser"/> is set.
         /// </summary>
-        Optional<int> ApproximatePresenceCount { get; }
+        new Optional<int> ApproximatePresenceCount { get; }
 
         /// <summary>
         /// Gets the approximate count of total members.
         /// </summary>
-        Optional<int> ApproximateMemberCount { get; }
+        new Optional<int> ApproximateMemberCount { get; }
 
         /// <summary>
         /// Gets the expiration date of this invite.
         /// </summary>
-        Optional<DateTimeOffset?> ExpiresAt { get; }
+        new Optional<DateTimeOffset?> ExpiresAt { get; }
 
         /// <summary>
         /// Gets metadata about the stage instance the invite is for, if any.
         /// </summary>
-        Optional<IInviteStageInstance> StageInstance { get; }
+        new Optional<IInviteStageInstance> StageInstance { get; }
+
+        /// <inheritdoc/>
+        Optional<string> IPartialInvite.Code => this.Code;
+
+        /// <inheritdoc/>
+        Optional<IPartialGuild> IPartialInvite.Guild => this.Guild;
+
+        /// <inheritdoc/>
+        Optional<IPartialChannel> IPartialInvite.Channel => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        Optional<IUser> IPartialInvite.Inviter => this.Inviter;
+
+        /// <inheritdoc/>
+        Optional<InviteTarget> IPartialInvite.TargetType => this.TargetType;
+
+        /// <inheritdoc/>
+        Optional<IPartialUser> IPartialInvite.TargetUser => this.TargetUser;
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialInvite.TargetApplication => this.TargetApplication;
+
+        /// <inheritdoc/>
+        Optional<int> IPartialInvite.ApproximatePresenceCount => this.ApproximatePresenceCount;
+
+        /// <inheritdoc/>
+        Optional<int> IPartialInvite.ApproximateMemberCount => this.ApproximateMemberCount;
+
+        /// <inheritdoc/>
+        Optional<DateTimeOffset?> IPartialInvite.ExpiresAt => this.ExpiresAt;
+
+        /// <inheritdoc/>
+        Optional<IInviteStageInstance> IPartialInvite.StageInstance => this.StageInstance;
     }
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Messages/IMessage.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Messages/IMessage.cs
@@ -204,7 +204,7 @@ namespace Remora.Discord.API.Abstractions.Objects
         Optional<Snowflake> IPartialMessage.GuildID => this.GuildID;
 
         /// <inheritdoc/>
-        Optional<IUser> IPartialMessage.Author => throw new NotImplementedException();
+        Optional<IUser> IPartialMessage.Author => new(this.Author);
 
         /// <inheritdoc/>
         Optional<IPartialGuildMember> IPartialMessage.Member => this.Member;
@@ -225,19 +225,19 @@ namespace Remora.Discord.API.Abstractions.Objects
         Optional<bool> IPartialMessage.MentionsEveryone => this.MentionsEveryone;
 
         /// <inheritdoc/>
-        Optional<IReadOnlyList<IUserMention>> IPartialMessage.Mentions => throw new NotImplementedException();
+        Optional<IReadOnlyList<IUserMention>> IPartialMessage.Mentions => new(this.Mentions);
 
         /// <inheritdoc/>
-        Optional<IReadOnlyList<Snowflake>> IPartialMessage.MentionedRoles => throw new NotImplementedException();
+        Optional<IReadOnlyList<Snowflake>> IPartialMessage.MentionedRoles => new(this.MentionedRoles);
 
         /// <inheritdoc/>
         Optional<IReadOnlyList<IChannelMention>> IPartialMessage.MentionedChannels => this.MentionedChannels;
 
         /// <inheritdoc/>
-        Optional<IReadOnlyList<IAttachment>> IPartialMessage.Attachments => throw new NotImplementedException();
+        Optional<IReadOnlyList<IAttachment>> IPartialMessage.Attachments => new(this.Attachments);
 
         /// <inheritdoc/>
-        Optional<IReadOnlyList<IEmbed>> IPartialMessage.Embeds => throw new NotImplementedException();
+        Optional<IReadOnlyList<IEmbed>> IPartialMessage.Embeds => new(this.Embeds);
 
         /// <inheritdoc/>
         Optional<IReadOnlyList<IReaction>> IPartialMessage.Reactions => this.Reactions;

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Messages/IMessage.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Messages/IMessage.cs
@@ -31,71 +31,71 @@ namespace Remora.Discord.API.Abstractions.Objects
     /// Represents a message.
     /// </summary>
     [PublicAPI]
-    public interface IMessage
+    public interface IMessage : IPartialMessage
     {
         /// <summary>
         /// Gets the message ID.
         /// </summary>
-        Snowflake ID { get; }
+        new Snowflake ID { get; }
 
         /// <summary>
         /// Gets the ID of the channel the message was sent in.
         /// </summary>
-        Snowflake ChannelID { get; }
+        new Snowflake ChannelID { get; }
 
         /// <summary>
         /// Gets the ID of the guild the message was sent in.
         /// </summary>
-        Optional<Snowflake> GuildID { get; }
+        new Optional<Snowflake> GuildID { get; }
 
         /// <summary>
         /// Gets the author of the message. This author is not guaranteed to be a valid user; in the case of a webhook
         /// message, the object corresponds to the webhook's ID, username, and avatar - this is the case when
         /// <see cref="WebhookID"/> contains a valid value.
         /// </summary>
-        IUser Author { get; }
+        new IUser Author { get; }
 
         /// <summary>
         /// Gets the member properties for the author. The member object exists in MESSAGE_CREATE and
         /// MESSAGE_UPDATE events from text-based guild channels. This allows bots to obtain real-time member data
         /// without requiring bots to keep member state in memory.
         /// </summary>
-        Optional<IPartialGuildMember> Member { get; }
+        new Optional<IPartialGuildMember> Member { get; }
 
         /// <summary>
         /// Gets the contents of the message.
         /// </summary>
-        string Content { get; }
+        new string Content { get; }
 
         /// <summary>
         /// Gets the time when the messages was sent.
         /// </summary>
-        DateTimeOffset Timestamp { get; }
+        new DateTimeOffset Timestamp { get; }
 
         /// <summary>
         /// Gets the time when the message was last edited.
         /// </summary>
-        DateTimeOffset? EditedTimestamp { get; }
+        new DateTimeOffset? EditedTimestamp { get; }
 
         /// <summary>
         /// Gets a value indicating whether this was a TTS message.
         /// </summary>
-        bool IsTTS { get; }
+        new bool IsTTS { get; }
 
         /// <summary>
         /// Gets a value indicating whether this message mentions everyone.
         /// </summary>
-        bool MentionsEveryone { get; }
+        new bool MentionsEveryone { get; }
 
         /// <summary>
         /// Gets a list of users mentioned in the message.
         /// </summary>
-        IReadOnlyList<IUserMention> Mentions { get; }
+        new IReadOnlyList<IUserMention> Mentions { get; }
 
         /// <summary>
         /// Gets a list of mentioned roles.
         /// </summary>
-        IReadOnlyList<Snowflake> MentionedRoles { get; }
+        new IReadOnlyList<Snowflake> MentionedRoles { get; }
 
         /// <summary>
         /// Gets a list of channel mentions.
@@ -106,92 +106,182 @@ namespace Remora.Discord.API.Abstractions.Objects
         /// meet these requirements, this field will not be sent.
         /// </remarks>
         /// </summary>
-        Optional<IReadOnlyList<IChannelMention>> MentionedChannels { get; }
+        new Optional<IReadOnlyList<IChannelMention>> MentionedChannels { get; }
 
         /// <summary>
         /// Gets a list of attached files.
         /// </summary>
-        IReadOnlyList<IAttachment> Attachments { get; }
+        new IReadOnlyList<IAttachment> Attachments { get; }
 
         /// <summary>
         /// Gets a list of embeds.
         /// </summary>
-        IReadOnlyList<IEmbed> Embeds { get; }
+        new IReadOnlyList<IEmbed> Embeds { get; }
 
         /// <summary>
         /// Gets an array of reaction objects.
         /// </summary>
-        Optional<IReadOnlyList<IReaction>> Reactions { get; }
+        new Optional<IReadOnlyList<IReaction>> Reactions { get; }
 
         /// <summary>
         /// Gets a nonce, used for validating a message was sent. Technically, this can be either an integer or a
         /// string.
         /// </summary>
-        Optional<string> Nonce { get; }
+        new Optional<string> Nonce { get; }
 
         /// <summary>
         /// Gets a value indicating whether the messages is pinned.
         /// </summary>
-        bool IsPinned { get; }
+        new bool IsPinned { get; }
 
         /// <summary>
         /// Gets the ID of the webhook that sent this message.
         /// </summary>
-        Optional<Snowflake> WebhookID { get; }
+        new Optional<Snowflake> WebhookID { get; }
 
         /// <summary>
         /// Gets the message type.
         /// </summary>
-        MessageType Type { get; }
+        new MessageType Type { get; }
 
         /// <summary>
         /// Gets the activity the message belongs to. Sent with rich presence-related chat embeds.
         /// </summary>
-        Optional<IMessageActivity> Activity { get; }
+        new Optional<IMessageActivity> Activity { get; }
 
         /// <summary>
         /// Gets the application the message belongs to. Sent with rich presence-related chat embeds.
         /// </summary>
-        Optional<IPartialApplication> Application { get; }
+        new Optional<IPartialApplication> Application { get; }
 
         /// <summary>
         /// Gets the ID of the application the message's interaction belongs to. Sent with interactions.
         /// </summary>
-        Optional<Snowflake> ApplicationID { get; }
+        new Optional<Snowflake> ApplicationID { get; }
 
         /// <summary>
         /// Gets the message reference. Sent with cross-posted messages.
         /// </summary>
-        Optional<IMessageReference> MessageReference { get;  }
+        new Optional<IMessageReference> MessageReference { get;  }
 
         /// <summary>
         /// Gets a set of bitwise flags describing extra features of the message.
         /// </summary>
-        Optional<MessageFlags> Flags { get; }
+        new Optional<MessageFlags> Flags { get; }
 
         /// <summary>
         /// Gets the referenced message, if any. A null value in this context refers to a deleted message.
         /// </summary>
-        Optional<IMessage?> ReferencedMessage { get; }
+        new Optional<IMessage?> ReferencedMessage { get; }
 
         /// <summary>
         /// Gets the interaction associated with this message, if any.
         /// </summary>
-        Optional<IMessageInteraction> Interaction { get; }
+        new Optional<IMessageInteraction> Interaction { get; }
 
         /// <summary>
         /// Gets the thread that was started from this message, if any.
         /// </summary>
-        Optional<IChannel> Thread { get; }
+        new Optional<IChannel> Thread { get; }
 
         /// <summary>
         /// Gets the components in the message.
         /// </summary>
-        Optional<IReadOnlyList<IMessageComponent>> Components { get; }
+        new Optional<IReadOnlyList<IMessageComponent>> Components { get; }
 
         /// <summary>
         /// Gets the stickers sent with the message.
         /// </summary>
-        Optional<IReadOnlyList<IStickerItem>> StickerItems { get; }
+        new Optional<IReadOnlyList<IStickerItem>> StickerItems { get; }
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialMessage.ID => this.ID;
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialMessage.ChannelID => this.ChannelID;
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialMessage.GuildID => this.GuildID;
+
+        /// <inheritdoc/>
+        Optional<IUser> IPartialMessage.Author => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        Optional<IPartialGuildMember> IPartialMessage.Member => this.Member;
+
+        /// <inheritdoc/>
+        Optional<string> IPartialMessage.Content => this.Content;
+
+        /// <inheritdoc/>
+        Optional<DateTimeOffset> IPartialMessage.Timestamp => this.Timestamp;
+
+        /// <inheritdoc/>
+        Optional<DateTimeOffset?> IPartialMessage.EditedTimestamp => this.EditedTimestamp;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialMessage.IsTTS => this.IsTTS;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialMessage.MentionsEveryone => this.MentionsEveryone;
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<IUserMention>> IPartialMessage.Mentions => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<Snowflake>> IPartialMessage.MentionedRoles => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<IChannelMention>> IPartialMessage.MentionedChannels => this.MentionedChannels;
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<IAttachment>> IPartialMessage.Attachments => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<IEmbed>> IPartialMessage.Embeds => throw new NotImplementedException();
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<IReaction>> IPartialMessage.Reactions => this.Reactions;
+
+        /// <inheritdoc/>
+        Optional<string> IPartialMessage.Nonce => this.Nonce;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialMessage.IsPinned => this.IsPinned;
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialMessage.WebhookID => this.WebhookID;
+
+        /// <inheritdoc/>
+        Optional<MessageType> IPartialMessage.Type => this.Type;
+
+        /// <inheritdoc/>
+        Optional<IMessageActivity> IPartialMessage.Activity => this.Activity;
+
+        /// <inheritdoc/>
+        Optional<IPartialApplication> IPartialMessage.Application => this.Application;
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialMessage.ApplicationID => this.ApplicationID;
+
+        /// <inheritdoc/>
+        Optional<IMessageReference> IPartialMessage.MessageReference => this.MessageReference;
+
+        /// <inheritdoc/>
+        Optional<MessageFlags> IPartialMessage.Flags => this.Flags;
+
+        /// <inheritdoc/>
+        Optional<IMessage?> IPartialMessage.ReferencedMessage => this.ReferencedMessage;
+
+        /// <inheritdoc/>
+        Optional<IMessageInteraction> IPartialMessage.Interaction => this.Interaction;
+
+        /// <inheritdoc/>
+        Optional<IChannel> IPartialMessage.Thread => this.Thread;
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<IMessageComponent>> IPartialMessage.Components => this.Components;
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<IStickerItem>> IPartialMessage.StickerItems => this.StickerItems;
     }
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Permissions/IRole.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Permissions/IRole.cs
@@ -93,7 +93,7 @@ namespace Remora.Discord.API.Abstractions.Objects
         Optional<int> IPartialRole.Position => this.Position;
 
         /// <inheritdoc/>
-        Optional<IDiscordPermissionSet> IPartialRole.Permissions => throw new System.NotImplementedException();
+        Optional<IDiscordPermissionSet> IPartialRole.Permissions => new(this.Permissions);
 
         /// <inheritdoc/>
         Optional<bool> IPartialRole.IsManaged => this.IsManaged;

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Permissions/IRole.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Permissions/IRole.cs
@@ -30,51 +30,78 @@ namespace Remora.Discord.API.Abstractions.Objects
     /// Represents a Discord role.
     /// </summary>
     [PublicAPI]
-    public interface IRole
+    public interface IRole : IPartialRole
     {
         /// <summary>
         /// Gets the ID of the role.
         /// </summary>
-        Snowflake ID { get; }
+        new Snowflake ID { get; }
 
         /// <summary>
         /// Gets the name of the role.
         /// </summary>
-        string Name { get; }
+        new string Name { get; }
 
         /// <summary>
         /// Gets the colour of the role.
         /// </summary>
-        Color Colour { get; }
+        new Color Colour { get; }
 
         /// <summary>
         /// Gets a value indicating whether the role is displayed separately in the sidebar.
         /// </summary>
-        bool IsHoisted { get; }
+        new bool IsHoisted { get; }
 
         /// <summary>
         /// Gets the position of the role.
         /// </summary>
-        int Position { get; }
+        new int Position { get; }
 
         /// <summary>
         /// Gets the permission set for this role.
         /// </summary>
-        IDiscordPermissionSet Permissions { get; }
+        new IDiscordPermissionSet Permissions { get; }
 
         /// <summary>
         /// Gets a value indicating whether this role is managed by an integration.
         /// </summary>
-        bool IsManaged { get; }
+        new bool IsManaged { get; }
 
         /// <summary>
         /// Gets a value indicating whether this role is mentionable.
         /// </summary>
-        bool IsMentionable { get; }
+        new bool IsMentionable { get; }
 
         /// <summary>
         /// Gets the tags the role has.
         /// </summary>
-        Optional<IRoleTags> Tags { get; }
+        new Optional<IRoleTags> Tags { get; }
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialRole.ID => this.ID;
+
+        /// <inheritdoc/>
+        Optional<string> IPartialRole.Name => this.Name;
+
+        /// <inheritdoc/>
+        Optional<Color> IPartialRole.Colour => this.Colour;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialRole.IsHoisted => this.IsHoisted;
+
+        /// <inheritdoc/>
+        Optional<int> IPartialRole.Position => this.Position;
+
+        /// <inheritdoc/>
+        Optional<IDiscordPermissionSet> IPartialRole.Permissions => throw new System.NotImplementedException();
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialRole.IsManaged => this.IsManaged;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialRole.IsMentionable => this.IsMentionable;
+
+        /// <inheritdoc/>
+        Optional<IRoleTags> IPartialRole.Tags => this.Tags;
     }
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Presence/IPresence.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Presence/IPresence.cs
@@ -30,31 +30,46 @@ namespace Remora.Discord.API.Abstractions.Objects
     /// Represents a user's presence.
     /// </summary>
     [PublicAPI]
-    public interface IPresence
+    public interface IPresence : IPartialPresence
     {
         /// <summary>
         /// Gets the user the presence is being updated for.
         /// </summary>
-        IPartialUser User { get; }
+        new IPartialUser User { get; }
 
         /// <summary>
         /// Gets the ID of the guild.
         /// </summary>
-        Snowflake GuildID { get; }
+        new Snowflake GuildID { get; }
 
         /// <summary>
         /// Gets the current status of the user.
         /// </summary>
-        ClientStatus Status { get; }
+        new ClientStatus Status { get; }
 
         /// <summary>
         /// Gets the user's current activities.
         /// </summary>
-        IReadOnlyList<IActivity>? Activities { get; }
+        new IReadOnlyList<IActivity>? Activities { get; }
 
         /// <summary>
         /// Gets the user's platform-dependent status.
         /// </summary>
-        IClientStatuses ClientStatus { get; }
+        new IClientStatuses ClientStatus { get; }
+
+        /// <inheritdoc/>
+        Optional<IPartialUser> IPartialPresence.User => throw new System.NotImplementedException();
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialPresence.GuildID => this.GuildID;
+
+        /// <inheritdoc/>
+        Optional<ClientStatus> IPartialPresence.Status => this.Status;
+
+        /// <inheritdoc/>
+        Optional<IReadOnlyList<IActivity>?> IPartialPresence.Activities => throw new System.NotImplementedException();
+
+        /// <inheritdoc/>
+        Optional<IClientStatuses> IPartialPresence.ClientStatus => throw new System.NotImplementedException();
     }
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Presence/IPresence.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Presence/IPresence.cs
@@ -58,7 +58,7 @@ namespace Remora.Discord.API.Abstractions.Objects
         new IClientStatuses ClientStatus { get; }
 
         /// <inheritdoc/>
-        Optional<IPartialUser> IPartialPresence.User => throw new System.NotImplementedException();
+        Optional<IPartialUser> IPartialPresence.User => new(this.User);
 
         /// <inheritdoc/>
         Optional<Snowflake> IPartialPresence.GuildID => this.GuildID;
@@ -67,9 +67,9 @@ namespace Remora.Discord.API.Abstractions.Objects
         Optional<ClientStatus> IPartialPresence.Status => this.Status;
 
         /// <inheritdoc/>
-        Optional<IReadOnlyList<IActivity>?> IPartialPresence.Activities => throw new System.NotImplementedException();
+        Optional<IReadOnlyList<IActivity>?> IPartialPresence.Activities => new(this.Activities);
 
         /// <inheritdoc/>
-        Optional<IClientStatuses> IPartialPresence.ClientStatus => throw new System.NotImplementedException();
+        Optional<IClientStatuses> IPartialPresence.ClientStatus => new(this.ClientStatus);
     }
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IUser.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IUser.cs
@@ -30,82 +30,127 @@ namespace Remora.Discord.API.Abstractions.Objects
     /// Represents a Discord user.
     /// </summary>
     [PublicAPI]
-    public interface IUser
+    public interface IUser : IPartialUser
     {
         /// <summary>
         /// Gets the ID of the user.
         /// </summary>
-        Snowflake ID { get; }
+        new Snowflake ID { get; }
 
         /// <summary>
         /// Gets the username of the user. This is not a unique value.
         /// </summary>
-        string Username { get; }
+        new string Username { get; }
 
         /// <summary>
         /// Gets the user's 4-digit discord tag.
         /// </summary>
-        ushort Discriminator { get; }
+        new ushort Discriminator { get; }
 
         /// <summary>
         /// Gets the user's avatar hash.
         /// </summary>
-        IImageHash? Avatar { get; }
+        new IImageHash? Avatar { get; }
 
         /// <summary>
         /// Gets a value indicating whether the user is a bot, belonging to an OAuth2 application.
         /// </summary>
-        Optional<bool> IsBot { get; }
+        new Optional<bool> IsBot { get; }
 
         /// <summary>
         /// Gets a value indicating whether the user is an official Discord system user (part of the urgent message
         /// system).
         /// </summary>
-        Optional<bool> IsSystem { get; }
+        new Optional<bool> IsSystem { get; }
 
         /// <summary>
         /// Gets a value indicating whether the user has multi-factor authentication enabled on their account.
         /// </summary>
-        Optional<bool> IsMFAEnabled { get; }
+        new Optional<bool> IsMFAEnabled { get; }
 
         /// <summary>
         /// Gets the user's banner.
         /// </summary>
-        Optional<IImageHash?> Banner { get; }
+        new Optional<IImageHash?> Banner { get; }
 
         /// <summary>
         /// Gets the user's banner colour.
         /// </summary>
-        Optional<Color?> AccentColour { get; }
+        new Optional<Color?> AccentColour { get; }
 
         /// <summary>
         /// Gets the user's chosen language option.
         /// </summary>
-        Optional<string> Locale { get; }
+        new Optional<string> Locale { get; }
 
         /// <summary>
         /// Gets a value indicating whether the email on the account has been verified.
         /// </summary>
-        Optional<bool> IsVerified { get; }
+        new Optional<bool> IsVerified { get; }
 
         /// <summary>
         /// Gets the user's email address.
         /// </summary>
-        Optional<string?> Email { get; }
+        new Optional<string?> Email { get; }
 
         /// <summary>
         /// Gets the flags on the user's account.
         /// </summary>
-        Optional<UserFlags> Flags { get; }
+        new Optional<UserFlags> Flags { get; }
 
         /// <summary>
         /// Gets the user's premium status.
         /// </summary>
-        Optional<PremiumType> PremiumType { get; }
+        new Optional<PremiumType> PremiumType { get; }
 
         /// <summary>
         /// Gets the flags on a user's account.
         /// </summary>
-        Optional<UserFlags> PublicFlags { get; }
+        new Optional<UserFlags> PublicFlags { get; }
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialUser.ID => this.ID;
+
+        /// <inheritdoc/>
+        Optional<string> IPartialUser.Username => this.Username;
+
+        /// <inheritdoc/>
+        Optional<ushort> IPartialUser.Discriminator => this.Discriminator;
+
+        /// <inheritdoc/>
+        Optional<IImageHash?> IPartialUser.Avatar => throw new System.NotImplementedException();
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialUser.IsBot => this.IsBot;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialUser.IsSystem => this.IsSystem;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialUser.IsMFAEnabled => this.IsMFAEnabled;
+
+        /// <inheritdoc/>
+        Optional<IImageHash?> IPartialUser.Banner => this.Banner;
+
+        /// <inheritdoc/>
+        Optional<Color?> IPartialUser.AccentColour => this.AccentColour;
+
+        /// <inheritdoc/>
+        Optional<string> IPartialUser.Locale => this.Locale;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialUser.IsVerified => this.IsVerified;
+
+        /// <inheritdoc/>
+        Optional<string?> IPartialUser.Email => this.Email;
+
+        /// <inheritdoc/>
+        Optional<UserFlags> IPartialUser.Flags => this.Flags;
+
+        /// <inheritdoc/>
+        Optional<PremiumType> IPartialUser.PremiumType => this.PremiumType;
+
+        /// <inheritdoc/>
+        Optional<UserFlags> IPartialUser.PublicFlags => this.PublicFlags;
     }
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IUser.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Users/IUser.cs
@@ -118,7 +118,7 @@ namespace Remora.Discord.API.Abstractions.Objects
         Optional<ushort> IPartialUser.Discriminator => this.Discriminator;
 
         /// <inheritdoc/>
-        Optional<IImageHash?> IPartialUser.Avatar => throw new System.NotImplementedException();
+        Optional<IImageHash?> IPartialUser.Avatar => new(this.Avatar);
 
         /// <inheritdoc/>
         Optional<bool> IPartialUser.IsBot => this.IsBot;

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Voice/IVoiceState.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Voice/IVoiceState.cs
@@ -30,71 +30,110 @@ namespace Remora.Discord.API.Abstractions.Objects
     /// Represents a user's voice connection status.
     /// </summary>
     [PublicAPI]
-    public interface IVoiceState
+    public interface IVoiceState : IPartialVoiceState
     {
         /// <summary>
         /// Gets the guild ID this voice state is for.
         /// </summary>
-        Optional<Snowflake> GuildID { get; }
+        new Optional<Snowflake> GuildID { get; }
 
         /// <summary>
         /// Gets the channel ID this user is connected to.
         /// </summary>
-        Snowflake? ChannelID { get; }
+        new Snowflake? ChannelID { get; }
 
         /// <summary>
         /// Gets the user ID this voice state is for.
         /// </summary>
-        Snowflake UserID { get; }
+        new Snowflake UserID { get; }
 
         /// <summary>
         /// Gets the guild member this voice state is for.
         /// </summary>
-        Optional<IGuildMember> Member { get; }
+        new Optional<IGuildMember> Member { get; }
 
         /// <summary>
         /// Gets the session ID for this voice state.
         /// </summary>
-        string SessionID { get; }
+        new string SessionID { get; }
 
         /// <summary>
         /// Gets a value indicating whether the user is deafened by the server.
         /// </summary>
-        bool IsDeafened { get; }
+        new bool IsDeafened { get; }
 
         /// <summary>
         /// Gets a value indicating whether the user is muted by the server.
         /// </summary>
-        bool IsMuted { get; }
+        new bool IsMuted { get; }
 
         /// <summary>
         /// Gets a value indicating whether the user is locally deafened.
         /// </summary>
-        bool IsSelfDeafened { get; }
+        new bool IsSelfDeafened { get; }
 
         /// <summary>
         /// Gets a value indicating whether the user is locally muted.
         /// </summary>
-        bool IsSelfMuted { get; }
+        new bool IsSelfMuted { get; }
 
         /// <summary>
         /// Gets a value indicating whether the user is currently streaming using "Go Live".
         /// </summary>
-        Optional<bool> IsStreaming { get; }
+        new Optional<bool> IsStreaming { get; }
 
         /// <summary>
         /// Gets a value indicating whether the user's camera is enabled.
         /// </summary>
-        bool IsVideoEnabled { get; }
+        new bool IsVideoEnabled { get; }
 
         /// <summary>
         /// Gets a value indicating whether the user is muted by the current user.
         /// </summary>
-        bool IsSuppressed { get; }
+        new bool IsSuppressed { get; }
 
         /// <summary>
         /// Gets the time at which the user requested to speak.
         /// </summary>
-        DateTimeOffset? RequestToSpeakTimestamp { get; }
+        new DateTimeOffset? RequestToSpeakTimestamp { get; }
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialVoiceState.GuildID => this.GuildID;
+
+        /// <inheritdoc/>
+        Optional<Snowflake?> IPartialVoiceState.ChannelID => this.ChannelID;
+
+        /// <inheritdoc/>
+        Optional<Snowflake> IPartialVoiceState.UserID => this.UserID;
+
+        /// <inheritdoc/>
+        Optional<IGuildMember> IPartialVoiceState.Member => this.Member;
+
+        /// <inheritdoc/>
+        Optional<string> IPartialVoiceState.SessionID => this.SessionID;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialVoiceState.IsDeafened => this.IsDeafened;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialVoiceState.IsMuted => this.IsMuted;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialVoiceState.IsSelfDeafened => this.IsSelfDeafened;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialVoiceState.IsSelfMuted => this.IsSelfMuted;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialVoiceState.IsStreaming => this.IsStreaming;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialVoiceState.IsVideoEnabled => this.IsVideoEnabled;
+
+        /// <inheritdoc/>
+        Optional<bool> IPartialVoiceState.IsSuppressed => this.IsSuppressed;
+
+        /// <inheritdoc/>
+        Optional<DateTimeOffset?> IPartialVoiceState.RequestToSpeakTimestamp => this.RequestToSpeakTimestamp;
     }
 }


### PR DESCRIPTION
This change explicitly implements the partial variants of interfaces on the full interface for types that have a partial variant. Effectively, this allows you to use non-partial objects (`Application`, `Message`, etc) as their partial counterparts without any extra code, streamlining some interactions between various API methods.

As it stands, everything seems to work as expected, but I'd like some feedback before I merge this.