### PR TITLE
Removed unneeded Package Reference in the Hosting project.

### DIFF
--- a/Remora.Discord.Hosting/Remora.Discord.Hosting.csproj
+++ b/Remora.Discord.Hosting/Remora.Discord.Hosting.csproj
@@ -21,7 +21,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
       <PackageReference Include="Remora.Extensions.Options.Immutable" Version="1.0.0" />
     </ItemGroup>


### PR DESCRIPTION
Removed unneeded package reference that is automatically referenced inside of Microsoft.Extensions.DependencyInjection which is referenced in the Remora.Discord.API project, which is referenced by the Remora.Discord.Rest project, which is referenced by the Remora.Discord.Gateway project, which is then referenced by the Remora.Discord.Hosting project.