### PR TITLE
Adds IDiscordPermissionSet#GetPermissions

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Permissions/IDiscordPermissionSet.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Permissions/IDiscordPermissionSet.cs
@@ -20,6 +20,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+using System.Collections.Generic;
 using System.Numerics;
 using JetBrains.Annotations;
 
@@ -56,5 +57,11 @@ namespace Remora.Discord.API.Abstractions.Objects
         /// <param name="permission">The permission.</param>
         /// <returns>true if the given permission is in the set; otherwise, false.</returns>
         bool HasPermission(DiscordVoicePermission permission);
+
+        /// <summary>
+        /// Gets a list of the <see cref="DiscordPermission"/> values contained within the set.
+        /// </summary>
+        /// <returns>A list of <see cref="DiscordPermission"/> value.</returns>
+        IReadOnlyList<DiscordPermission> GetPermissions();
     }
 }

--- a/Backend/Remora.Discord.API/API/Objects/Permissions/DiscordPermissionSet.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Permissions/DiscordPermissionSet.cs
@@ -132,6 +132,26 @@ namespace Remora.Discord.API.Objects
             return isBitSet;
         }
 
+        /// <inheritdoc />
+        public IReadOnlyList<DiscordPermission> GetPermissions()
+        {
+            BigInteger value = this.Value;
+            List<DiscordPermission> permissions = new();
+
+            for (int index = 0; value != 0; index++)
+            {
+                int bit = (int)value & 0x1;
+                if (bit == 1)
+                {
+                    permissions.Add((DiscordPermission)index);
+                }
+
+                value >>= 1;
+            }
+
+            return permissions;
+        }
+
         /// <summary>
         /// Computes a full permission set for a user, taking roles and overwrites into account.
         /// </summary>

--- a/Tests/Remora.Discord.API.Tests/API/Objects/Permissions/DiscordPermissionSetTests.cs
+++ b/Tests/Remora.Discord.API.Tests/API/Objects/Permissions/DiscordPermissionSetTests.cs
@@ -308,5 +308,14 @@ namespace Remora.Discord.API.Tests.Objects
 
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public void CanGetPermissions()
+        {
+            var permissions = new DiscordPermission[] { DiscordPermission.AddReactions, DiscordPermission.Connect, DiscordPermission.UseVoiceActivity };
+            var permissionSet = new DiscordPermissionSet(permissions);
+
+            Assert.Equal(permissions, permissionSet.GetPermissions());
+        }
     }
 }


### PR DESCRIPTION
Following on from discussion in the Discord earlier, this method on the `IDiscordPermissionSet` interface provides a means to retrieve the permissions contained within the set in the form of the `DiscordPermission` enumeration.

I considered making this an extension method but felt it was fairly integral.