### PR TITLE
Fix DiscordPermissionSet#GetPermissions and Value storage.

### DIFF
--- a/Backend/Remora.Discord.API/API/Objects/Permissions/DiscordPermissionSet.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Permissions/DiscordPermissionSet.cs
@@ -86,7 +86,7 @@ namespace Remora.Discord.API.Objects
                 currentValue |= (byte)(1 << bitIndex);
             }
 
-            this.Value = new BigInteger(bytes);
+            this.Value = new BigInteger(bytes, true);
         }
 
         /// <summary>
@@ -135,12 +135,13 @@ namespace Remora.Discord.API.Objects
         /// <inheritdoc />
         public IReadOnlyList<DiscordPermission> GetPermissions()
         {
+            var comparator = new BigInteger(0x1);
             var value = this.Value;
             var permissions = new List<DiscordPermission>();
 
             for (var index = 0; value != 0; index++)
             {
-                var bit = (int)value & 0x1;
+                var bit = value & comparator;
                 if (bit == 1)
                 {
                     permissions.Add((DiscordPermission)index);

--- a/Backend/Remora.Discord.API/API/Objects/Permissions/DiscordPermissionSet.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Permissions/DiscordPermissionSet.cs
@@ -135,19 +135,23 @@ namespace Remora.Discord.API.Objects
         /// <inheritdoc />
         public IReadOnlyList<DiscordPermission> GetPermissions()
         {
-            var comparator = new BigInteger(0x1);
-            var value = this.Value;
             var permissions = new List<DiscordPermission>();
+            var valueBytes = this.Value.ToByteArray(true);
 
-            for (var index = 0; value != 0; index++)
+            for (var byteIndex = 0; byteIndex < valueBytes.Length; byteIndex++)
             {
-                var bit = value & comparator;
-                if (bit == 1)
-                {
-                    permissions.Add((DiscordPermission)index);
-                }
+                byte b = valueBytes[byteIndex];
 
-                value >>= 1;
+                for (var bitIndex = 0; b != 0; bitIndex++)
+                {
+                    var bitValue = b & 0x1;
+                    if (bitValue == 1)
+                    {
+                        permissions.Add((DiscordPermission)((byteIndex * 8) + bitIndex));
+                    }
+
+                    b >>= 1;
+                }
             }
 
             return permissions;

--- a/Tests/Remora.Discord.API.Tests/API/Objects/Permissions/DiscordPermissionSetTests.cs
+++ b/Tests/Remora.Discord.API.Tests/API/Objects/Permissions/DiscordPermissionSetTests.cs
@@ -312,7 +312,7 @@ namespace Remora.Discord.API.Tests.Objects
         [Fact]
         public void CanGetPermissions()
         {
-            var permissions = new DiscordPermission[] { DiscordPermission.AddReactions, DiscordPermission.Connect, DiscordPermission.UseVoiceActivity };
+            var permissions = new DiscordPermission[] { DiscordPermission.AddReactions, DiscordPermission.Connect, DiscordPermission.UseVoiceActivity, DiscordPermission.SendMessagesInThreads, DiscordPermission.StartEmbeddedActivities };
             var permissionSet = new DiscordPermissionSet(permissions);
 
             Assert.Equal(permissions, permissionSet.GetPermissions());

--- a/Tests/Remora.Discord.API.Tests/API/Objects/Permissions/DiscordPermissionSetTests.cs
+++ b/Tests/Remora.Discord.API.Tests/API/Objects/Permissions/DiscordPermissionSetTests.cs
@@ -99,6 +99,20 @@ namespace Remora.Discord.API.Tests.Objects
             Assert.False(permissions.HasPermission(permission));
         }
 
+        /// <summary>
+        /// Tests that <see cref="DiscordPermissionSet.HasPermission(DiscordPermission)"/> works correctly for large integers that are considered signed as default by <see cref="BigInteger"/>.
+        /// </summary>
+        [Fact]
+        public void HasPermissionReturnsTrueForLargeIntegers()
+        {
+            var permissions = new DiscordPermission[] { DiscordPermission.AddReactions, DiscordPermission.Connect, DiscordPermission.UseVoiceActivity, DiscordPermission.SendMessagesInThreads, DiscordPermission.StartEmbeddedActivities };
+
+            var permissionSet = new DiscordPermissionSet(permissions);
+            var permission = DiscordPermission.StartEmbeddedActivities;
+
+            Assert.True(permissionSet.HasPermission(permission));
+        }
+
         [Fact]
         public void CanComputeMemberPermissions()
         {


### PR DESCRIPTION
Firstly, this PR fixes my recent `DiscordPermissionSet#GetPermissions` addition by removing an erronous integer cast and subsequently re-writing the algorithm for a ~15x speed improvement after some benchmarking. Shoulda copied your logic straight off the bat, Jax 😄.

Secondly, I've noticed that with the addition of the latest permission `StartEmbeddedActivities`, `BigInteger` was starting to consider some permission values as being signed, causing at least `HasPermission` to fail (specifically when trying to retrieve the byte array of the value in an unsigned form). To resolve this, the value is now explicitly marked as unsigned upon construction.