### PR TITLE
Add Messages property to IApplicationCommandInteractionDataResolved

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/IApplicationCommandInteractionDataResolved.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/IApplicationCommandInteractionDataResolved.cs
@@ -49,5 +49,10 @@ namespace Remora.Discord.API.Abstractions.Objects
         /// Gets the resolved channels, if any.
         /// </summary>
         Optional<IReadOnlyDictionary<Snowflake, IPartialChannel>> Channels { get; }
+
+        /// <summary>
+        /// Gets the resolved messages, if any.
+        /// </summary>
+        Optional<IReadOnlyDictionary<Snowflake, IPartialMessage>> Messages { get; }
     }
 }

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/ApplicationCommandInteractionDataResolved.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/ApplicationCommandInteractionDataResolved.cs
@@ -36,7 +36,8 @@ namespace Remora.Discord.API.Objects
         Optional<IReadOnlyDictionary<Snowflake, IUser>> Users,
         Optional<IReadOnlyDictionary<Snowflake, IPartialGuildMember>> Members,
         Optional<IReadOnlyDictionary<Snowflake, IRole>> Roles,
-        Optional<IReadOnlyDictionary<Snowflake, IPartialChannel>> Channels
+        Optional<IReadOnlyDictionary<Snowflake, IPartialChannel>> Channels,
+        Optional<IReadOnlyDictionary<Snowflake, IPartialMessage>> Messages
     )
     : IApplicationCommandInteractionDataResolved;
 }

--- a/Backend/Remora.Discord.API/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/Remora.Discord.API/Extensions/ServiceCollectionExtensions.cs
@@ -850,7 +850,8 @@ namespace Remora.Discord.API.Extensions
                 .WithPropertyConverter(r => r.Users, new SnowflakeDictionaryConverter<IUser>())
                 .WithPropertyConverter(r => r.Members, new SnowflakeDictionaryConverter<IPartialGuildMember>())
                 .WithPropertyConverter(r => r.Roles, new SnowflakeDictionaryConverter<IRole>())
-                .WithPropertyConverter(r => r.Channels, new SnowflakeDictionaryConverter<IPartialChannel>());
+                .WithPropertyConverter(r => r.Channels, new SnowflakeDictionaryConverter<IPartialChannel>())
+                .WithPropertyConverter(r => r.Messages, new SnowflakeDictionaryConverter<IPartialMessage>());
 
             options.AddDataObjectConverter<IGuildApplicationCommandPermissions, GuildApplicationCommandPermissions>();
             options.AddDataObjectConverter

--- a/Tests/Remora.Discord.Tests/Samples/Objects/APPLICATION_COMMAND_INTERACTION_DATA_RESOLVED/APPLICATION_COMMAND_INTERACTION_DATA_RESOLVED.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/APPLICATION_COMMAND_INTERACTION_DATA_RESOLVED/APPLICATION_COMMAND_INTERACTION_DATA_RESOLVED.json
@@ -60,5 +60,31 @@
       "type": 0,
       "name": "none"
     }
+  },
+  "messages": {
+    "867793854505943041": {
+      "attachments": [],
+      "author": {
+        "avatar": "68b329da9893e34099c7d8ad5cb9c940",
+        "discriminator": "9999",
+        "id": "999999999999999999",
+        "public_flags": 1,
+        "username": "none"
+      },
+      "channel_id": "999999999999999999",
+      "components": [],
+      "content": "none",
+      "edited_timestamp": null,
+      "embeds": [],
+      "flags": 0,
+      "id": "999999999999999999",
+      "mention_everyone": false,
+      "mention_roles": [],
+      "mentions": [],
+      "pinned": false,
+      "timestamp": "1970-01-01T00:00:00.000000+00:00",
+      "tts": false,
+      "type": 0
+    }
   }
 }


### PR DESCRIPTION
This property is included with resolved application command data when receiving a message command interaction.

Note that there are failing tests related to ephemeral commands. These don't appear to be related to this addition and instead were introduced in [#19a0664](https://github.com/Nihlus/Remora.Discord/commit/19a066415c257a3c14f8e0d4e0247d97591cc9dd)