### PR TITLE
Add Per-Guild Avatars and ModifyCurrentMember

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Gateway/Events/Guilds/IGuildMemberUpdate.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Gateway/Events/Guilds/IGuildMemberUpdate.cs
@@ -55,6 +55,11 @@ namespace Remora.Discord.API.Abstractions.Gateway.Events
         Optional<string?> Nickname { get; }
 
         /// <summary>
+        /// Gets the member's guild avatar hash.
+        /// </summary>
+        Optional<IImageHash?> Avatar { get; }
+
+        /// <summary>
         /// Gets the date when the user joined the guild.
         /// </summary>
         DateTimeOffset? JoinedAt { get; }

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Guilds/IGuildMember.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Guilds/IGuildMember.cs
@@ -44,6 +44,11 @@ namespace Remora.Discord.API.Abstractions.Objects
         new Optional<string?> Nickname { get; }
 
         /// <summary>
+        /// Gets the member's guild avatar hash.
+        /// </summary>
+        new Optional<IImageHash?> Avatar { get; }
+
+        /// <summary>
         /// Gets the roles the user has.
         /// </summary>
         new IReadOnlyList<Snowflake> Roles { get; }
@@ -83,6 +88,9 @@ namespace Remora.Discord.API.Abstractions.Objects
 
         /// <inheritdoc/>
         Optional<string?> IPartialGuildMember.Nickname => this.Nickname;
+
+        /// <inheritdoc />
+        Optional<IImageHash?> IPartialGuildMember.Avatar => this.Avatar;
 
         /// <inheritdoc/>
         Optional<IReadOnlyList<Snowflake>> IPartialGuildMember.Roles => new(this.Roles);

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Guilds/IPartialGuildMember.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Guilds/IPartialGuildMember.cs
@@ -39,6 +39,9 @@ namespace Remora.Discord.API.Abstractions.Objects
         /// <inheritdoc cref="IGuildMember.Nickname" />
         Optional<string?> Nickname { get; }
 
+        /// <inheritdoc cref="IGuildMember.Avatar"/>
+        Optional<IImageHash?> Avatar { get; }
+
         /// <inheritdoc cref="IGuildMember.Roles" />
         Optional<IReadOnlyList<Snowflake>> Roles { get; }
 

--- a/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestGuildAPI.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestGuildAPI.cs
@@ -357,7 +357,7 @@ namespace Remora.Discord.API.Abstractions.Rest
         /// <param name="reason">The reason to mark the action in the audit log with.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A modification result which may or may not have succeeded.</returns>
-        [Obsolete($"Deprecated in favour of {nameof(ModifyCurrentMemberAsync)}.")]
+        [Obsolete("Deprecated in favour of " + nameof(ModifyCurrentMemberAsync) + ".")]
         Task<Result<string>> ModifyCurrentUserNickAsync
         (
             Snowflake guildID,

--- a/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestGuildAPI.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestGuildAPI.cs
@@ -340,12 +340,14 @@ namespace Remora.Discord.API.Abstractions.Rest
         /// </summary>
         /// <param name="guildID">The ID of the guild.</param>
         /// <param name="nickname">The new nickname.</param>
+        /// <param name="reason">The reason to mark the action in the audit log with.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A modification result which may or may not have succeeded, containing the updated member.</returns>
         Task<Result<IGuildMember>> ModifyCurrentMemberAsync
         (
             Snowflake guildID,
             Optional<string?> nickname = default,
+            Optional<string> reason = default,
             CancellationToken ct = default
         );
 

--- a/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestGuildAPI.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestGuildAPI.cs
@@ -336,6 +336,20 @@ namespace Remora.Discord.API.Abstractions.Rest
         );
 
         /// <summary>
+        /// Modifies the current member.
+        /// </summary>
+        /// <param name="guildID">The ID of the guild.</param>
+        /// <param name="nickname">The new nickname.</param>
+        /// <param name="ct">The cancellation token for this operation.</param>
+        /// <returns>A modification result which may or may not have succeeded, containing the updated member.</returns>
+        Task<Result<IGuildMember>> ModifyCurrentMemberAsync
+        (
+            Snowflake guildID,
+            Optional<string?> nickname = default,
+            CancellationToken ct = default
+        );
+
+        /// <summary>
         /// Modifies the nickname of the current user.
         /// </summary>
         /// <param name="guildID">The ID of the guild.</param>
@@ -343,6 +357,7 @@ namespace Remora.Discord.API.Abstractions.Rest
         /// <param name="reason">The reason to mark the action in the audit log with.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A modification result which may or may not have succeeded.</returns>
+        [Obsolete($"Deprecated in favour of {nameof(ModifyCurrentMemberAsync)}.")]
         Task<Result<string>> ModifyCurrentUserNickAsync
         (
             Snowflake guildID,

--- a/Backend/Remora.Discord.API/API/Gateway/Events/Guilds/GuildMemberAdd.cs
+++ b/Backend/Remora.Discord.API/API/Gateway/Events/Guilds/GuildMemberAdd.cs
@@ -42,6 +42,7 @@ namespace Remora.Discord.API.Gateway.Events
         (
             Optional<IUser> user,
             Optional<string?> nickname,
+            Optional<IImageHash?> avatar,
             IReadOnlyList<Snowflake> roles,
             DateTimeOffset joinedAt,
             Optional<DateTimeOffset?> premiumSince,
@@ -55,6 +56,7 @@ namespace Remora.Discord.API.Gateway.Events
             (
                 user,
                 nickname,
+                avatar,
                 roles,
                 joinedAt,
                 premiumSince,

--- a/Backend/Remora.Discord.API/API/Gateway/Events/Guilds/GuildMemberUpdate.cs
+++ b/Backend/Remora.Discord.API/API/Gateway/Events/Guilds/GuildMemberUpdate.cs
@@ -39,6 +39,7 @@ namespace Remora.Discord.API.Gateway.Events
         IReadOnlyList<Snowflake> Roles,
         IUser User,
         Optional<string?> Nickname = default,
+        Optional<IImageHash?> Avatar = default,
         DateTimeOffset? JoinedAt = default,
         Optional<DateTimeOffset?> PremiumSince = default,
         Optional<bool> IsPending = default,

--- a/Backend/Remora.Discord.API/API/Objects/Guilds/GuildMember.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Guilds/GuildMember.cs
@@ -36,6 +36,7 @@ namespace Remora.Discord.API.Objects
     (
         Optional<IUser> User,
         Optional<string?> Nickname,
+        Optional<IImageHash?> Avatar,
         IReadOnlyList<Snowflake> Roles,
         DateTimeOffset JoinedAt,
         Optional<DateTimeOffset?> PremiumSince,

--- a/Backend/Remora.Discord.API/API/Objects/Guilds/PartialGuildMember.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Guilds/PartialGuildMember.cs
@@ -36,6 +36,7 @@ namespace Remora.Discord.API.Objects
     (
         Optional<IUser> User = default,
         Optional<string?> Nickname = default,
+        Optional<IImageHash?> Avatar = default,
         Optional<IReadOnlyList<Snowflake>> Roles = default,
         Optional<DateTimeOffset> JoinedAt = default,
         Optional<DateTimeOffset?> PremiumSince = default,

--- a/Backend/Remora.Discord.Caching/Responders/EarlyCacheResponder.cs
+++ b/Backend/Remora.Discord.Caching/Responders/EarlyCacheResponder.cs
@@ -176,6 +176,7 @@ namespace Remora.Discord.Caching.Responders
                 (
                     new Optional<IUser>(gatewayEvent.User),
                     gatewayEvent.Nickname.IsDefined(out var nickname) ? nickname : cachedInstance.Nickname,
+                    gatewayEvent.Avatar,
                     gatewayEvent.Roles,
                     gatewayEvent.JoinedAt ?? cachedInstance.JoinedAt,
                     gatewayEvent.PremiumSince.IsDefined(out var premiumSince) ? premiumSince : cachedInstance.PremiumSince,
@@ -191,6 +192,7 @@ namespace Remora.Discord.Caching.Responders
                 (
                     new Optional<IUser>(gatewayEvent.User),
                     gatewayEvent.Nickname,
+                    gatewayEvent.Avatar,
                     gatewayEvent.Roles,
                     gatewayEvent.JoinedAt.Value,
                     gatewayEvent.PremiumSince,

--- a/Backend/Remora.Discord.Rest/API/Guilds/DiscordRestGuildAPI.cs
+++ b/Backend/Remora.Discord.Rest/API/Guilds/DiscordRestGuildAPI.cs
@@ -550,7 +550,7 @@ namespace Remora.Discord.Rest.API
         }
 
         /// <inheritdoc />
-        [Obsolete($"Deprecated in favour of {nameof(ModifyCurrentMemberAsync)}.")]
+        [Obsolete("Deprecated in favour of " + nameof(ModifyCurrentMemberAsync) + ".")]
         public virtual Task<Result<string>> ModifyCurrentUserNickAsync
         (
             Snowflake guildID,

--- a/Backend/Remora.Discord.Rest/API/Guilds/DiscordRestGuildAPI.cs
+++ b/Backend/Remora.Discord.Rest/API/Guilds/DiscordRestGuildAPI.cs
@@ -537,6 +537,7 @@ namespace Remora.Discord.Rest.API
         (
             Snowflake guildID,
             Optional<string?> nickname = default,
+            Optional<string> reason = default,
             CancellationToken ct = default
         )
         {
@@ -544,6 +545,7 @@ namespace Remora.Discord.Rest.API
             (
                 $"guilds/{guildID}/members/@me",
                 b => b
+                    .AddAuditLogReason(reason)
                     .WithJson(json => json.Write("nick", nickname, this.JsonOptions)),
                 ct: ct
             );

--- a/Backend/Remora.Discord.Rest/API/Guilds/DiscordRestGuildAPI.cs
+++ b/Backend/Remora.Discord.Rest/API/Guilds/DiscordRestGuildAPI.cs
@@ -533,6 +533,24 @@ namespace Remora.Discord.Rest.API
         }
 
         /// <inheritdoc />
+        public virtual Task<Result<IGuildMember>> ModifyCurrentMemberAsync
+        (
+            Snowflake guildID,
+            Optional<string?> nickname = default,
+            CancellationToken ct = default
+        )
+        {
+            return this.DiscordHttpClient.PatchAsync<IGuildMember>
+            (
+                $"guilds/{guildID}/members/@me",
+                b => b
+                    .WithJson(json => json.Write("nick", nickname, this.JsonOptions)),
+                ct: ct
+            );
+        }
+
+        /// <inheritdoc />
+        [Obsolete($"Deprecated in favour of {nameof(ModifyCurrentMemberAsync)}.")]
         public virtual Task<Result<string>> ModifyCurrentUserNickAsync
         (
             Snowflake guildID,

--- a/Samples/UnknownEventLogger/Responders/UnknownEventResponder.cs
+++ b/Samples/UnknownEventLogger/Responders/UnknownEventResponder.cs
@@ -80,7 +80,7 @@ namespace Remora.Discord.Samples.UnknownEventLogger.Responders
             }
 
             var sequenceNumber = eventSequenceElement.GetInt64();
-            var logTime = $"{DateTime.UtcNow:u}";
+            var logTime = DateTimeOffset.UtcNow.ToString("yyyy-MM-dd");
 
             _log.LogInformation("Received an event of type \"{EventType}\"", eventType);
 

--- a/Tests/Remora.Discord.API.Tests/API/CDNTests.cs
+++ b/Tests/Remora.Discord.API.Tests/API/CDNTests.cs
@@ -618,6 +618,127 @@ namespace Remora.Discord.API.Tests
         }
 
         /// <summary>
+        /// Tests the <see cref="CDN.GetGuildMemberAvatarUrl(Snowflake, IGuildMember, Optional{CDNImageFormat}, Optional{ushort})"/> method and
+        /// its overloads.
+        /// </summary>
+        public class GetGuildMemberAvatarUrl : CDNTestBase
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="GetGuildMemberAvatarUrl"/> class.
+            /// </summary>
+            public GetGuildMemberAvatarUrl()
+                : base
+                (
+                    new Uri("https://cdn.discordapp.com/guilds/0/users/1/avatars/2"),
+                    new[] { CDNImageFormat.PNG, CDNImageFormat.JPEG, CDNImageFormat.WebP, CDNImageFormat.GIF }
+                )
+            {
+            }
+
+            /// <summary>
+            /// Tests whether the correct address is returned when the instance has an animated image.
+            /// </summary>
+            [Fact]
+            public void ReturnsCorrectAddressWithAnimatedImage()
+            {
+                var expected = new Uri("https://cdn.discordapp.com/guilds/0/users/1/avatars/a_2.gif");
+
+                var guildID = new Snowflake(0);
+                var userID = new Snowflake(1);
+                var imageHash = new ImageHash("a_2");
+
+                var mockedUser = new Mock<IUser>();
+                mockedUser.SetupGet(g => g.ID).Returns(userID);
+
+                var mockedMember = new Mock<IGuildMember>();
+                mockedMember.SetupGet(g => g.Avatar).Returns(imageHash);
+                mockedMember.SetupGet(g => g.User).Returns(new Optional<IUser>(mockedUser.Object));
+
+                var member = mockedMember.Object;
+
+                var getActual = CDN.GetGuildMemberAvatarUrl(guildID, member);
+
+                Assert.True(getActual.IsSuccess);
+                Assert.Equal(expected, getActual.Entity);
+            }
+
+            /// <summary>
+            /// Tests whether the correct address is returned when the instance has an animated image, but a custom
+            /// format is explicitly requested.
+            /// </summary>
+            [Fact]
+            public void ReturnsCorrectAddressWithAnimatedImageAndCustomFormat()
+            {
+                var expected = new Uri("https://cdn.discordapp.com/guilds/0/users/1/avatars/a_2.png");
+
+                var guildID = new Snowflake(0);
+                var userID = new Snowflake(1);
+                var imageHash = new ImageHash("a_2");
+
+                var mockedUser = new Mock<IUser>();
+                mockedUser.SetupGet(g => g.ID).Returns(userID);
+
+                var mockedMember = new Mock<IGuildMember>();
+                mockedMember.SetupGet(g => g.Avatar).Returns(imageHash);
+                mockedMember.SetupGet(g => g.User).Returns(new Optional<IUser>(mockedUser.Object));
+
+                var member = mockedMember.Object;
+
+                var getActual = CDN.GetGuildMemberAvatarUrl(guildID, member, CDNImageFormat.PNG);
+
+                Assert.True(getActual.IsSuccess);
+                Assert.Equal(expected, getActual.Entity);
+            }
+
+            /// <summary>
+            /// Tests whether the correct address is returned when the instance has no image set.
+            /// </summary>
+            [Fact]
+            public void ReturnsUnsuccessfulResultIfInstanceHasNoImage()
+            {
+                var guildID = new Snowflake(0);
+                var userID = new Snowflake(1);
+
+                var mockedUser = new Mock<IUser>();
+                mockedUser.SetupGet(g => g.ID).Returns(userID);
+
+                var mockedMember = new Mock<IGuildMember>();
+                mockedMember.SetupGet(g => g.Avatar).Returns(new Optional<IImageHash?>(null));
+                mockedMember.SetupGet(g => g.User).Returns(new Optional<IUser>(mockedUser.Object));
+
+                var member = mockedMember.Object;
+
+                var getActual = CDN.GetGuildMemberAvatarUrl(guildID, member, CDNImageFormat.PNG);
+
+                Assert.False(getActual.IsSuccess);
+                Assert.IsType<ImageNotFoundError>(getActual.Error);
+            }
+
+            /// <inheritdoc />
+            protected override IEnumerable<Result<Uri>> GetImageUris
+            (
+                Optional<CDNImageFormat> imageFormat = default,
+                Optional<ushort> imageSize = default
+            )
+            {
+                var guildID = new Snowflake(0);
+                var userID = new Snowflake(1);
+                var imageHash = new ImageHash("2");
+
+                var mockedUser = new Mock<IUser>();
+                mockedUser.SetupGet(g => g.ID).Returns(userID);
+
+                var mockedMember = new Mock<IGuildMember>();
+                mockedMember.SetupGet(g => g.Avatar).Returns(imageHash);
+                mockedMember.SetupGet(g => g.User).Returns(new Optional<IUser>(mockedUser.Object));
+
+                var member = mockedMember.Object;
+                yield return CDN.GetGuildMemberAvatarUrl(guildID, member, imageFormat, imageSize);
+                yield return CDN.GetGuildMemberAvatarUrl(guildID, userID, imageHash, imageFormat, imageSize);
+            }
+        }
+
+        /// <summary>
         /// Tests the <see cref="CDN.GetApplicationIconUrl(IApplication, Optional{CDNImageFormat}, Optional{ushort})"/>
         /// method and its overloads.
         /// </summary>

--- a/Tests/Remora.Discord.Rest.Tests/API/Guild/DiscordRestGuildAPITests.cs
+++ b/Tests/Remora.Discord.Rest.Tests/API/Guild/DiscordRestGuildAPITests.cs
@@ -1130,6 +1130,46 @@ namespace Remora.Discord.Rest.Tests.API.Guild
         }
 
         /// <summary>
+        /// Tests the <see cref="DiscordRestGuildAPI.ModifyCurrentMemberAsync"/> method.
+        /// </summary>
+        public class ModifyCurrentMemberAsync : RestAPITestBase<IDiscordRestGuildAPI>
+        {
+            /// <summary>
+            /// Tests whether the API method performs its request correctly.
+            /// </summary>
+            /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+            [Fact]
+            public async Task PerformsRequestCorrectly()
+            {
+                var guildId = new Snowflake(0);
+                var nick = "cdd";
+
+                var api = CreateAPI
+                (
+                    b => b
+                        .Expect(HttpMethod.Patch, $"{Constants.BaseURL}guilds/{guildId}/members/@me")
+                        .WithJson
+                        (
+                            j => j.IsObject
+                            (
+                                o => o
+                                    .WithProperty("nick", p => p.Is(nick))
+                            )
+                        )
+                        .Respond("application/json", SampleRepository.Samples[typeof(IGuildMember)])
+                );
+
+                var result = await api.ModifyCurrentMemberAsync
+                (
+                    guildId,
+                    nick
+                );
+
+                ResultAssert.Successful(result);
+            }
+        }
+
+        /// <summary>
         /// Tests the <see cref="DiscordRestGuildAPI.ModifyCurrentUserNickAsync"/> method.
         /// </summary>
         public class ModifyCurrentUserNickAsync : RestAPITestBase<IDiscordRestGuildAPI>

--- a/Tests/Remora.Discord.Rest.Tests/API/Guild/DiscordRestGuildAPITests.cs
+++ b/Tests/Remora.Discord.Rest.Tests/API/Guild/DiscordRestGuildAPITests.cs
@@ -1143,11 +1143,13 @@ namespace Remora.Discord.Rest.Tests.API.Guild
             {
                 var guildId = new Snowflake(0);
                 var nick = "cdd";
+                var reason = "test";
 
                 var api = CreateAPI
                 (
                     b => b
                         .Expect(HttpMethod.Patch, $"{Constants.BaseURL}guilds/{guildId}/members/@me")
+                        .WithHeaders(Constants.AuditLogHeaderName, reason)
                         .WithJson
                         (
                             j => j.IsObject
@@ -1162,7 +1164,8 @@ namespace Remora.Discord.Rest.Tests.API.Guild
                 var result = await api.ModifyCurrentMemberAsync
                 (
                     guildId,
-                    nick
+                    nick,
+                    reason
                 );
 
                 ResultAssert.Successful(result);


### PR DESCRIPTION
Started implementing the changes made in [commit d49d34b](https://github.com/discord/discord-api-docs/commit/d49d34bd5ffa3df659eb92bfa743af79c607d5cd) to the DAPI docs.

- [x] Add `CDN.GetGuildMemberAvatarUrl`.
- [x] Add the `Avatar` field to `IGuildMember` and related gateway events.
- [x] Add `IDiscordRestGuildAPI.ModifyCurrentMember`.

Note that there is a caveat here. The DAPI docs note that the new `avatar` field is required, however my current implementation  marks it as optional, as this is the behaviour observed from the API. I have created an [issue on the docs regarding this](https://github.com/discord/discord-api-docs/issues/3883).

I decided to do this in order to have correct functionality of the feature at this time, and because the same workaround has been utilised for role icons.