### PR TITLE
Add ChannelTypesAttribute

### DIFF
--- a/Remora.Discord.Commands/Attributes/ChannelTypeAttribute.cs
+++ b/Remora.Discord.Commands/Attributes/ChannelTypeAttribute.cs
@@ -1,0 +1,50 @@
+﻿//
+//  ChannelTypeAttribute.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using JetBrains.Annotations;
+using Remora.Discord.API.Abstractions.Objects;
+
+namespace Remora.Discord.Commands.Attributes
+{
+    /// <summary>
+    /// Marks a channel parameter with a type requirement for Discord slash commands, controlling what channel autocompletion is presented to the user.
+    /// </summary>
+    [PublicAPI]
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public class ChannelTypeAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets the configured type hint.
+        /// </summary>
+        public ChannelType Type { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChannelTypeAttribute"/> class.
+        /// </summary>
+        /// <param name="type">The type hint.</param>
+        public ChannelTypeAttribute(ChannelType type)
+        {
+            this.Type = type;
+        }
+    }
+}

--- a/Remora.Discord.Commands/Attributes/ChannelTypesAttribute.cs
+++ b/Remora.Discord.Commands/Attributes/ChannelTypesAttribute.cs
@@ -1,5 +1,5 @@
 ﻿//
-//  ChannelTypeAttribute.cs
+//  ChannelTypesAttribute.cs
 //
 //  Author:
 //       Jarl Gullberg <jarl.gullberg@gmail.com>
@@ -21,30 +21,31 @@
 //
 
 using System;
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
 
 namespace Remora.Discord.Commands.Attributes
 {
     /// <summary>
-    /// Marks a channel parameter with a type requirement for Discord slash commands, controlling what channel autocompletion is presented to the user.
+    /// Marks a channel parameter with type requirements for Discord slash commands, controlling what channel autocompletion is presented to the user.
     /// </summary>
     [PublicAPI]
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
-    public class ChannelTypeAttribute : Attribute
+    public class ChannelTypesAttribute : Attribute
     {
         /// <summary>
-        /// Gets the configured type hint.
+        /// Gets the types of channel that are allowed to be presented as an autocomplete option.
         /// </summary>
-        public ChannelType Type { get; }
+        public IReadOnlyList<ChannelType> Types { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ChannelTypeAttribute"/> class.
+        /// Initializes a new instance of the <see cref="ChannelTypesAttribute"/> class.
         /// </summary>
-        /// <param name="type">The type hint.</param>
-        public ChannelTypeAttribute(ChannelType type)
+        /// <param name="type">The types of channel that are allowed to be presented as an autocomplete option.</param>
+        public ChannelTypesAttribute(params ChannelType[] type)
         {
-            this.Type = type;
+            this.Types = type;
         }
     }
 }

--- a/Remora.Discord.Commands/Attributes/ChannelTypesAttribute.cs
+++ b/Remora.Discord.Commands/Attributes/ChannelTypesAttribute.cs
@@ -42,10 +42,10 @@ namespace Remora.Discord.Commands.Attributes
         /// <summary>
         /// Initializes a new instance of the <see cref="ChannelTypesAttribute"/> class.
         /// </summary>
-        /// <param name="type">The types of channel that are allowed to be presented as an autocomplete option.</param>
-        public ChannelTypesAttribute(params ChannelType[] type)
+        /// <param name="types">The types of channel that are allowed to be presented as an autocomplete option.</param>
+        public ChannelTypesAttribute(params ChannelType[] types)
         {
-            this.Types = type;
+            this.Types = types;
         }
     }
 }

--- a/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
@@ -438,11 +438,15 @@ namespace Remora.Discord.Commands.Extensions
             return Result<IReadOnlyList<IApplicationCommandOption>>.FromSuccess(parameterOptions);
         }
 
-        private static Result<Optional<IReadOnlyList<ChannelType>>> CreateChannelTypesOption(
-            CommandNode command, IParameterShape parameter, ApplicationCommandOptionType parameterType)
+        private static Result<Optional<IReadOnlyList<ChannelType>>> CreateChannelTypesOption
+        (
+            CommandNode command,
+            IParameterShape parameter,
+            ApplicationCommandOptionType parameterType
+        )
         {
             var channelTypesAttribute = parameter.Parameter.GetCustomAttribute<ChannelTypesAttribute>();
-            if (channelTypesAttribute is not null && parameterType != ApplicationCommandOptionType.Channel)
+            if (channelTypesAttribute is not null && parameterType is not ApplicationCommandOptionType.Channel)
             {
                 return new UnsupportedParameterFeatureError
                 (

--- a/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
@@ -394,6 +394,11 @@ namespace Remora.Discord.Commands.Extensions
                     ? ToApplicationCommandOptionType(parameterType)
                     : (ApplicationCommandOptionType)typeHint.TypeHint;
 
+                var channelTypesAttribute = parameter.Parameter.GetCustomAttribute<ChannelTypesAttribute>();
+                var channelTypes = channelTypesAttribute is null
+                    ? default(Optional<IReadOnlyList<ChannelType>>)
+                    : new Optional<IReadOnlyList<ChannelType>>(channelTypesAttribute.Types);
+
                 Optional<IReadOnlyList<IApplicationCommandOptionChoice>> choices = default;
                 if (parameterType.IsEnum)
                 {
@@ -413,7 +418,8 @@ namespace Remora.Discord.Commands.Extensions
                     parameter.Description,
                     default,
                     !parameter.IsOmissible(),
-                    choices
+                    choices,
+                    ChannelTypes: channelTypes
                 );
 
                 parameterOptions.Add(parameterOption);

--- a/Samples/SlashCommands/Commands/HttpCatCommands.cs
+++ b/Samples/SlashCommands/Commands/HttpCatCommands.cs
@@ -140,14 +140,18 @@ namespace Remora.Discord.Samples.SlashCommands.Commands
         }
 
         /// <summary>
-        /// Posts a HTTP error code cat.
+        /// Posts a HTTP error code cat that mathematically 'matches' a channel.
+        /// The clientside autocompletion of channel selections is restricted to guild text channels
+        /// by the <see cref="ChannelTypesAttribute"/> on the <paramref name="channel"/> parameter.
         /// </summary>
         /// <param name="channel">The channel to cattify.</param>
         /// <returns>The result of the command.</returns>
         [Command("channel-cat")]
         [Description("Posts a cat image that matches the provided channel.")]
-        public Task<IResult> PostChannelHttpCatAsync(
-            [Description("The channel to cattify")][ChannelTypes(ChannelType.GuildText)] IChannel channel)
+        public Task<IResult> PostChannelHttpCatAsync
+        (
+            [Description("The channel to cattify")][ChannelTypes(ChannelType.GuildText)] IChannel channel
+        )
         {
             var values = Enum.GetValues<HttpStatusCode>();
             var index = Map(channel.ID.Value, 0, ulong.MaxValue, 0, (ulong)(values.Length - 1));

--- a/Samples/SlashCommands/Commands/HttpCatCommands.cs
+++ b/Samples/SlashCommands/Commands/HttpCatCommands.cs
@@ -139,6 +139,23 @@ namespace Remora.Discord.Samples.SlashCommands.Commands
             return PostHttpCatAsync((int)code);
         }
 
+        /// <summary>
+        /// Posts a HTTP error code cat.
+        /// </summary>
+        /// <param name="channel">The channel to cattify.</param>
+        /// <returns>The result of the command.</returns>
+        [Command("channel-cat")]
+        [Description("Posts a cat image that matches the provided channel.")]
+        public Task<IResult> PostChannelHttpCatAsync(
+            [Description("The channel to cattify")][ChannelTypes(ChannelType.GuildText)] IChannel channel)
+        {
+            var values = Enum.GetValues<HttpStatusCode>();
+            var index = Map(channel.ID.Value, 0, ulong.MaxValue, 0, (ulong)(values.Length - 1));
+
+            var code = values[index];
+            return PostHttpCatAsync((int)code);
+        }
+
         private static ulong Map(ulong value, ulong fromSource, ulong toSource, ulong fromTarget, ulong toTarget)
         {
             return ((value - fromSource) / (toSource - fromSource) * (toTarget - fromTarget)) + fromTarget;

--- a/Tests/Remora.Discord.Commands.Tests/Data/InternalLimits/ChannelTypesAttributeOnlyOnChannelParameter.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Data/InternalLimits/ChannelTypesAttributeOnlyOnChannelParameter.cs
@@ -1,0 +1,43 @@
+﻿//
+//  ChannelTypesAttributeOnlyOnChannelParameter.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Threading.Tasks;
+using Remora.Commands.Attributes;
+using Remora.Commands.Groups;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.Commands.Attributes;
+using Remora.Results;
+
+#pragma warning disable CS1591, SA1600
+
+namespace Remora.Discord.Commands.Tests.Data.InternalLimits
+{
+    public class ChannelTypesAttributeOnlyOnChannelParameter : CommandGroup
+    {
+        [Command("a")]
+        public Task<IResult> A([ChannelTypes(ChannelType.GuildText)] bool value)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Tests/Remora.Discord.Commands.Tests/Data/InternalLimits/ChannelTypesAttributeRequiresAtLeastOneValue.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Data/InternalLimits/ChannelTypesAttributeRequiresAtLeastOneValue.cs
@@ -1,0 +1,43 @@
+﻿//
+//  ChannelTypesAttributeRequiresAtLeastOneValue.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Threading.Tasks;
+using Remora.Commands.Attributes;
+using Remora.Commands.Groups;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.Commands.Attributes;
+using Remora.Results;
+
+#pragma warning disable CS1591, SA1600
+
+namespace Remora.Discord.Commands.Tests.Data.InternalLimits
+{
+    public class ChannelTypesAttributeRequiresAtLeastOneValue : CommandGroup
+    {
+        [Command("a")]
+        public Task<IResult> A([ChannelTypes] IChannel value)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Tests/Remora.Discord.Commands.Tests/Data/Valid/TypedCommands.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Data/Valid/TypedCommands.cs
@@ -130,6 +130,12 @@ namespace Remora.Discord.Commands.Tests.Data.Valid
             throw new NotImplementedException();
         }
 
+        [Command("typed-channel-value")]
+        public Task<IResult> CommandWithTypedChannelValue([ChannelTypes(ChannelType.GuildText)] IChannel value)
+        {
+            throw new NotImplementedException();
+        }
+
         [Command("member-value")]
         public Task<IResult> CommandWithMemberValue(IGuildMember value)
         {

--- a/Tests/Remora.Discord.Commands.Tests/Extensions/CommandTreeExtensionTests.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Extensions/CommandTreeExtensionTests.cs
@@ -276,6 +276,36 @@ namespace Remora.Discord.Commands.Tests.Extensions
                     var result = tree.CreateApplicationCommands();
                     ResultAssert.Unsuccessful(result);
                 }
+
+                /// <summary>
+                /// Tests whether method responds appropriately to a failure case.
+                /// </summary>
+                [Fact]
+                public void ReturnsUnsuccessfulIfChannelTypesAttributeAppliedOnNonChannelParameter()
+                {
+                    var builder = new CommandTreeBuilder();
+                    builder.RegisterModule<ChannelTypesAttributeOnlyOnChannelParameter>();
+
+                    var tree = builder.Build();
+
+                    var result = tree.CreateApplicationCommands();
+                    ResultAssert.Unsuccessful(result);
+                }
+
+                /// <summary>
+                /// Tests whether method responds appropriately to a failure case.
+                /// </summary>
+                [Fact]
+                public void ReturnsUnsuccessfulIfChannelTypesAttributeHasZeroValues()
+                {
+                    var builder = new CommandTreeBuilder();
+                    builder.RegisterModule<ChannelTypesAttributeRequiresAtLeastOneValue>();
+
+                    var tree = builder.Build();
+
+                    var result = tree.CreateApplicationCommands();
+                    ResultAssert.Unsuccessful(result);
+                }
             }
 
             /// <summary>
@@ -384,7 +414,19 @@ namespace Remora.Discord.Commands.Tests.Extensions
 
                     AssertExistsWithType("role-value", Role);
                     AssertExistsWithType("user-value", User);
+
                     AssertExistsWithType("channel-value", Channel);
+                    var channelCommand = commands.First(c => c.Name == "channel-value");
+                    var channelParameter = channelCommand.Options.Value[0];
+                    Assert.False(channelParameter.ChannelTypes.HasValue);
+
+                    AssertExistsWithType("typed-channel-value", Channel);
+                    var typedChannelCommand = commands.First(c => c.Name == "typed-channel-value");
+                    var typedChannelParameter = typedChannelCommand.Options.Value[0];
+                    Assert.True(typedChannelParameter.ChannelTypes.HasValue);
+                    Assert.True(typedChannelParameter.ChannelTypes.Value.Count == 1);
+                    Assert.True(typedChannelParameter.ChannelTypes.Value[0] == ChannelType.GuildText);
+
                     AssertExistsWithType("member-value", User);
 
                     AssertExistsWithType("enum-value", String);


### PR DESCRIPTION
Adds the `ChannelTypesAttribute` to the commands library, allowing channel types to be specified on `IChannel` command parameters, aiding autocomplete. This builds on #107.

```csharp
[Command("channel-type-demo")]
public async Task<IResult> ChannelTypeDemoCommandAsync(
    [ChannelTypes(ChannelType.GuildText, ChannelType.GuildVoice)] IChannel channel)
{
    ...
}
```