### PR TITLE
Add FeedbackMessageOptions to expose additional options on feedback messages.

### DIFF
--- a/Remora.Discord.Commands/Feedback/Messages/FeedbackMessageOptions.cs
+++ b/Remora.Discord.Commands/Feedback/Messages/FeedbackMessageOptions.cs
@@ -1,0 +1,54 @@
+﻿//
+//  FeedbackMessageOptions.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.Core;
+
+namespace Remora.Discord.Commands.Feedback.Messages
+{
+    /// <summary>
+    /// Defines options to customise a feedback message response.
+    /// </summary>
+    public record FeedbackMessageOptions
+    {
+        /// <summary>
+        /// Gets a value indicating whether the message should use text-to-speech.
+        /// </summary>
+        public Optional<bool> IsTTS { get; init; }
+
+        /// <summary>
+        /// Gets a file to send with the message.
+        /// </summary>
+        public Optional<FileData> File { get; init; }
+
+        /// <summary>
+        /// Gets the allowed mentions for the message.
+        /// </summary>
+        public Optional<IAllowedMentions> AllowedMentions { get; init; }
+
+        /// <summary>
+        /// Gets a list of message components to include with the message.
+        /// </summary>
+        public Optional<IReadOnlyList<IMessageComponent>> MessageComponents { get; init; }
+    }
+}

--- a/Remora.Discord.Commands/Feedback/Messages/FeedbackMessageOptions.cs
+++ b/Remora.Discord.Commands/Feedback/Messages/FeedbackMessageOptions.cs
@@ -29,26 +29,15 @@ namespace Remora.Discord.Commands.Feedback.Messages
     /// <summary>
     /// Defines options to customise a feedback message response.
     /// </summary>
+    /// <param name="IsTTS">Indicates whether the message should use text-to-speech.</param>
+    /// <param name="File">A file to send with the message.</param>
+    /// <param name="AllowedMentions">The allowed mentions for the message.</param>
+    /// <param name="MessageComponents">A list of message components to include with the message.</param>
     public record FeedbackMessageOptions
-    {
-        /// <summary>
-        /// Gets a value indicating whether the message should use text-to-speech.
-        /// </summary>
-        public Optional<bool> IsTTS { get; init; }
-
-        /// <summary>
-        /// Gets a file to send with the message.
-        /// </summary>
-        public Optional<FileData> File { get; init; }
-
-        /// <summary>
-        /// Gets the allowed mentions for the message.
-        /// </summary>
-        public Optional<IAllowedMentions> AllowedMentions { get; init; }
-
-        /// <summary>
-        /// Gets a list of message components to include with the message.
-        /// </summary>
-        public Optional<IReadOnlyList<IMessageComponent>> MessageComponents { get; init; }
-    }
+    (
+        Optional<bool> IsTTS,
+        Optional<FileData> File,
+        Optional<IAllowedMentions> AllowedMentions,
+        Optional<IReadOnlyList<IMessageComponent>> MessageComponents
+    );
 }

--- a/Remora.Discord.Commands/Feedback/Messages/FeedbackMessageOptions.cs
+++ b/Remora.Discord.Commands/Feedback/Messages/FeedbackMessageOptions.cs
@@ -35,9 +35,9 @@ namespace Remora.Discord.Commands.Feedback.Messages
     /// <param name="MessageComponents">A list of message components to include with the message.</param>
     public record FeedbackMessageOptions
     (
-        Optional<bool> IsTTS,
-        Optional<FileData> File,
-        Optional<IAllowedMentions> AllowedMentions,
-        Optional<IReadOnlyList<IMessageComponent>> MessageComponents
+        Optional<bool> IsTTS = default,
+        Optional<FileData> File = default,
+        Optional<IAllowedMentions> AllowedMentions = default,
+        Optional<IReadOnlyList<IMessageComponent>> MessageComponents = default
     );
 }

--- a/Remora.Discord.Commands/Feedback/Services/FeedbackService.cs
+++ b/Remora.Discord.Commands/Feedback/Services/FeedbackService.cs
@@ -99,6 +99,7 @@ namespace Remora.Discord.Commands.Feedback.Services
         /// <param name="channel">The channel to send the message to.</param>
         /// <param name="contents">The contents of the message.</param>
         /// <param name="target">The target user to mention, if any.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<Result<IReadOnlyList<IMessage>>> SendInfoAsync
@@ -106,9 +107,10 @@ namespace Remora.Discord.Commands.Feedback.Services
             Snowflake channel,
             string contents,
             Snowflake? target = null,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
-            => SendMessageAsync(channel, new FeedbackMessage(contents, this.Theme.Primary), target, ct);
+            => SendMessageAsync(channel, new FeedbackMessage(contents, this.Theme.Primary), target, options, ct);
 
         /// <summary>
         /// Send an informational message wherever is most appropriate to the current context.
@@ -119,30 +121,34 @@ namespace Remora.Discord.Commands.Feedback.Services
         /// </remarks>
         /// <param name="contents">The contents of the message.</param>
         /// <param name="target">The target user to mention, if any.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<Result<IReadOnlyList<IMessage>>> SendContextualInfoAsync
         (
             string contents,
             Snowflake? target = null,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
-            => SendContextualMessageAsync(new FeedbackMessage(contents, this.Theme.Primary), target, ct);
+            => SendContextualMessageAsync(new FeedbackMessage(contents, this.Theme.Primary), target, options, ct);
 
         /// <summary>
         /// Send an informational message to the given user as a direct message.
         /// </summary>
         /// <param name="user">The user to send the message to.</param>
         /// <param name="contents">The contents of the message.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<Result<IReadOnlyList<IMessage>>> SendPrivateInfoAsync
         (
             Snowflake user,
             string contents,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
-            => SendPrivateMessageAsync(user, new FeedbackMessage(contents, this.Theme.Primary), ct);
+            => SendPrivateMessageAsync(user, new FeedbackMessage(contents, this.Theme.Primary), options, ct);
 
         /// <summary>
         /// Send a positive, successful message.
@@ -150,6 +156,7 @@ namespace Remora.Discord.Commands.Feedback.Services
         /// <param name="channel">The channel to send the message to.</param>
         /// <param name="contents">The contents of the message.</param>
         /// <param name="target">The target user to mention, if any.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<Result<IReadOnlyList<IMessage>>> SendSuccessAsync
@@ -157,9 +164,10 @@ namespace Remora.Discord.Commands.Feedback.Services
             Snowflake channel,
             string contents,
             Snowflake? target = null,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
-            => SendMessageAsync(channel, new FeedbackMessage(contents, this.Theme.Success), target, ct);
+            => SendMessageAsync(channel, new FeedbackMessage(contents, this.Theme.Success), target, options, ct);
 
         /// <summary>
         /// Send a positive, successful message wherever is most appropriate to the current context.
@@ -170,30 +178,34 @@ namespace Remora.Discord.Commands.Feedback.Services
         /// </remarks>
         /// <param name="contents">The contents of the message.</param>
         /// <param name="target">The target user to mention, if any.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<Result<IReadOnlyList<IMessage>>> SendContextualSuccessAsync
         (
             string contents,
             Snowflake? target = null,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
-            => SendContextualMessageAsync(new FeedbackMessage(contents, this.Theme.Success), target, ct);
+            => SendContextualMessageAsync(new FeedbackMessage(contents, this.Theme.Success), target, options, ct);
 
         /// <summary>
         /// Send a positive, successful message to the given user as a direct message.
         /// </summary>
         /// <param name="user">The user to send the message to.</param>
         /// <param name="contents">The contents of the message.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<Result<IReadOnlyList<IMessage>>> SendPrivateSuccessAsync
         (
             Snowflake user,
             string contents,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
-            => SendPrivateMessageAsync(user, new FeedbackMessage(contents, this.Theme.Success), ct);
+            => SendPrivateMessageAsync(user, new FeedbackMessage(contents, this.Theme.Success), options, ct);
 
         /// <summary>
         /// Send a neutral message.
@@ -201,6 +213,7 @@ namespace Remora.Discord.Commands.Feedback.Services
         /// <param name="channel">The channel to send the message to.</param>
         /// <param name="contents">The contents of the message.</param>
         /// <param name="target">The target user to mention, if any.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<Result<IReadOnlyList<IMessage>>> SendNeutralAsync
@@ -208,9 +221,10 @@ namespace Remora.Discord.Commands.Feedback.Services
             Snowflake channel,
             string contents,
             Snowflake? target = null,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
-            => SendMessageAsync(channel, new FeedbackMessage(contents, this.Theme.Secondary), target, ct);
+            => SendMessageAsync(channel, new FeedbackMessage(contents, this.Theme.Secondary), target, options, ct);
 
         /// <summary>
         /// Send a neutral message wherever is most appropriate to the current context.
@@ -221,30 +235,34 @@ namespace Remora.Discord.Commands.Feedback.Services
         /// </remarks>
         /// <param name="contents">The contents of the message.</param>
         /// <param name="target">The target user to mention, if any.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<Result<IReadOnlyList<IMessage>>> SendContextualNeutralAsync
         (
             string contents,
             Snowflake? target = null,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
-            => SendContextualMessageAsync(new FeedbackMessage(contents, this.Theme.Secondary), target, ct);
+            => SendContextualMessageAsync(new FeedbackMessage(contents, this.Theme.Secondary), target, options, ct);
 
         /// <summary>
         /// Send a neutral message to the given user as a direct message.
         /// </summary>
         /// <param name="user">The user to send the message to.</param>
         /// <param name="contents">The contents of the message.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<Result<IReadOnlyList<IMessage>>> SendPrivateNeutralAsync
         (
             Snowflake user,
             string contents,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
-            => SendPrivateMessageAsync(user, new FeedbackMessage(contents, this.Theme.Secondary), ct);
+            => SendPrivateMessageAsync(user, new FeedbackMessage(contents, this.Theme.Secondary), options, ct);
 
         /// <summary>
         /// Send a warning message.
@@ -252,6 +270,7 @@ namespace Remora.Discord.Commands.Feedback.Services
         /// <param name="channel">The channel to send the message to.</param>
         /// <param name="contents">The contents of the message.</param>
         /// <param name="target">The target user to mention, if any.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<Result<IReadOnlyList<IMessage>>> SendWarningAsync
@@ -259,9 +278,10 @@ namespace Remora.Discord.Commands.Feedback.Services
             Snowflake channel,
             string contents,
             Snowflake? target = null,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
-            => SendMessageAsync(channel, new FeedbackMessage(contents, this.Theme.Warning), target, ct);
+            => SendMessageAsync(channel, new FeedbackMessage(contents, this.Theme.Warning), target, options, ct);
 
         /// <summary>
         /// Send a warning message wherever is most appropriate to the current context.
@@ -272,30 +292,34 @@ namespace Remora.Discord.Commands.Feedback.Services
         /// </remarks>
         /// <param name="contents">The contents of the message.</param>
         /// <param name="target">The target user to mention, if any.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<Result<IReadOnlyList<IMessage>>> SendContextualWarningAsync
         (
             string contents,
             Snowflake? target = null,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
-            => SendContextualMessageAsync(new FeedbackMessage(contents, this.Theme.Warning), target, ct);
+            => SendContextualMessageAsync(new FeedbackMessage(contents, this.Theme.Warning), target, options, ct);
 
         /// <summary>
         /// Send a warning message to the given user as a direct message.
         /// </summary>
         /// <param name="user">The user to send the message to.</param>
         /// <param name="contents">The contents of the message.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<Result<IReadOnlyList<IMessage>>> SendPrivateWarningAsync
         (
             Snowflake user,
             string contents,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
-            => SendPrivateMessageAsync(user, new FeedbackMessage(contents, this.Theme.Warning), ct);
+            => SendPrivateMessageAsync(user, new FeedbackMessage(contents, this.Theme.Warning), options, ct);
 
         /// <summary>
         /// Send a negative error message.
@@ -303,6 +327,7 @@ namespace Remora.Discord.Commands.Feedback.Services
         /// <param name="channel">The channel to send the message to.</param>
         /// <param name="contents">The contents of the message.</param>
         /// <param name="target">The target user to mention, if any.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<Result<IReadOnlyList<IMessage>>> SendErrorAsync
@@ -310,9 +335,10 @@ namespace Remora.Discord.Commands.Feedback.Services
             Snowflake channel,
             string contents,
             Snowflake? target = null,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
-            => SendMessageAsync(channel, new FeedbackMessage(contents, this.Theme.FaultOrDanger), target, ct);
+            => SendMessageAsync(channel, new FeedbackMessage(contents, this.Theme.FaultOrDanger), target, options, ct);
 
         /// <summary>
         /// Send a negative error message wherever is most appropriate to the current context.
@@ -323,30 +349,34 @@ namespace Remora.Discord.Commands.Feedback.Services
         /// </remarks>
         /// <param name="contents">The contents of the message.</param>
         /// <param name="target">The target user to mention, if any.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<Result<IReadOnlyList<IMessage>>> SendContextualErrorAsync
         (
             string contents,
             Snowflake? target = null,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
-            => SendContextualMessageAsync(new FeedbackMessage(contents, this.Theme.FaultOrDanger), target, ct);
+            => SendContextualMessageAsync(new FeedbackMessage(contents, this.Theme.FaultOrDanger), target, options, ct);
 
         /// <summary>
         /// Send a negative error message to the given user as a direct message.
         /// </summary>
         /// <param name="user">The user to send the message to.</param>
         /// <param name="contents">The contents of the message.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<Result<IReadOnlyList<IMessage>>> SendPrivateErrorAsync
         (
             Snowflake user,
             string contents,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
-            => SendPrivateMessageAsync(user, new FeedbackMessage(contents, this.Theme.FaultOrDanger), ct);
+            => SendPrivateMessageAsync(user, new FeedbackMessage(contents, this.Theme.FaultOrDanger), options, ct);
 
         /// <summary>
         /// Send a message.
@@ -354,6 +384,7 @@ namespace Remora.Discord.Commands.Feedback.Services
         /// <param name="channel">The channel to send the message to.</param>
         /// <param name="message">The message to send.</param>
         /// <param name="target">The target user to mention, if any.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<Result<IReadOnlyList<IMessage>>> SendMessageAsync
@@ -361,66 +392,84 @@ namespace Remora.Discord.Commands.Feedback.Services
             Snowflake channel,
             FeedbackMessage message,
             Snowflake? target = null,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
-            => SendContentAsync(channel, message.Message, message.Colour, target, ct);
+            => SendContentAsync(channel, message.Message, message.Colour, target, options, ct);
 
         /// <summary>
         /// Send a contextual message.
         /// </summary>
         /// <param name="message">The message to send.</param>
         /// <param name="target">The target user to mention, if any.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<Result<IReadOnlyList<IMessage>>> SendContextualMessageAsync
         (
             FeedbackMessage message,
             Snowflake? target = null,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
-            => SendContextualContentAsync(message.Message, message.Colour, target, ct);
+            => SendContextualContentAsync(message.Message, message.Colour, target, options, ct);
 
         /// <summary>
         /// Send a private message.
         /// </summary>
         /// <param name="user">The user to send the message to.</param>
         /// <param name="message">The message to send.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<Result<IReadOnlyList<IMessage>>> SendPrivateMessageAsync
         (
             Snowflake user,
             FeedbackMessage message,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
-            => SendPrivateContentAsync(user, message.Message, message.Colour, ct);
+            => SendPrivateContentAsync(user, message.Message, message.Colour, options, ct);
 
         /// <summary>
         /// Sends the given embed to the given channel.
         /// </summary>
         /// <param name="channel">The channel to send the embed to.</param>
         /// <param name="embed">The embed.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public Task<Result<IMessage>> SendEmbedAsync
         (
             Snowflake channel,
             Embed embed,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
         {
-            return _channelAPI.CreateMessageAsync(channel, embeds: new[] { embed }, ct: ct);
+            return _channelAPI.CreateMessageAsync
+            (
+                channel,
+                isTTS: options?.IsTTS ?? default,
+                file: options?.File ?? default,
+                embeds: new[] { embed },
+                allowedMentions: options?.AllowedMentions ?? default,
+                components: options?.MessageComponents ?? default,
+                ct: ct
+            );
         }
 
         /// <summary>
         /// Sends the given embed to current context.
         /// </summary>
         /// <param name="embed">The embed.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<Result<IMessage>> SendContextualEmbedAsync
         (
             Embed embed,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
         {
@@ -433,12 +482,7 @@ namespace Remora.Discord.Commands.Feedback.Services
             {
                 case MessageContext messageContext:
                 {
-                    return await _channelAPI.CreateMessageAsync
-                    (
-                        messageContext.ChannelID,
-                        embeds: new[] { embed },
-                        ct: ct
-                    );
+                    return await SendEmbedAsync(messageContext.ChannelID, embed, options, ct);
                 }
                 case InteractionContext interactionContext:
                 {
@@ -452,7 +496,11 @@ namespace Remora.Discord.Commands.Feedback.Services
                     (
                         interactionContext.ApplicationID,
                         interactionContext.Token,
+                        isTTS: options?.IsTTS ?? default,
+                        file: options?.File ?? default,
                         embeds: new[] { embed },
+                        allowedMentions: options?.AllowedMentions ?? default,
+                        components: options?.MessageComponents ?? default,
                         flags: messageFlags,
                         ct: ct
                     );
@@ -485,12 +533,14 @@ namespace Remora.Discord.Commands.Feedback.Services
         /// </summary>
         /// <param name="user">The ID of the user to send the embed to.</param>
         /// <param name="embed">The embed.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<Result<IMessage>> SendPrivateEmbedAsync
         (
             Snowflake user,
             Embed embed,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
         {
@@ -502,7 +552,7 @@ namespace Remora.Discord.Commands.Feedback.Services
 
             var dm = getUserDM.Entity;
 
-            return await SendEmbedAsync(dm.ID, embed, ct);
+            return await SendEmbedAsync(dm.ID, embed, options, ct);
         }
 
         /// <summary>
@@ -512,6 +562,7 @@ namespace Remora.Discord.Commands.Feedback.Services
         /// <param name="contents">The contents to send.</param>
         /// <param name="color">The embed colour.</param>
         /// <param name="target">The target user to mention, if any.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<Result<IReadOnlyList<IMessage>>> SendContentAsync
@@ -520,13 +571,14 @@ namespace Remora.Discord.Commands.Feedback.Services
             string contents,
             Color color,
             Snowflake? target = null,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
         {
             var sendResults = new List<IMessage>();
             foreach (var chunk in CreateContentChunks(target, color, contents))
             {
-                var send = await SendEmbedAsync(channel, chunk, ct);
+                var send = await SendEmbedAsync(channel, chunk, options, ct);
                 if (!send.IsSuccess)
                 {
                     return Result<IReadOnlyList<IMessage>>.FromError(send);
@@ -544,6 +596,7 @@ namespace Remora.Discord.Commands.Feedback.Services
         /// <param name="contents">The contents to send.</param>
         /// <param name="color">The embed colour.</param>
         /// <param name="target">The target user to mention, if any.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<Result<IReadOnlyList<IMessage>>> SendContextualContentAsync
@@ -551,13 +604,14 @@ namespace Remora.Discord.Commands.Feedback.Services
             string contents,
             Color color,
             Snowflake? target = null,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
         {
             var sendResults = new List<IMessage>();
             foreach (var chunk in CreateContentChunks(target, color, contents))
             {
-                var send = await SendContextualEmbedAsync(chunk, ct);
+                var send = await SendContextualEmbedAsync(chunk, options, ct);
                 if (!send.IsSuccess)
                 {
                     return Result<IReadOnlyList<IMessage>>.FromError(send);
@@ -576,6 +630,7 @@ namespace Remora.Discord.Commands.Feedback.Services
         /// <param name="user">The ID of the user to send the content to.</param>
         /// <param name="contents">The contents to send.</param>
         /// <param name="color">The embed colour.</param>
+        /// <param name="options">The message options to use.</param>
         /// <param name="ct">The cancellation token for this operation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task<Result<IReadOnlyList<IMessage>>> SendPrivateContentAsync
@@ -583,6 +638,7 @@ namespace Remora.Discord.Commands.Feedback.Services
             Snowflake user,
             string contents,
             Color color,
+            FeedbackMessageOptions? options = null,
             CancellationToken ct = default
         )
         {
@@ -593,7 +649,7 @@ namespace Remora.Discord.Commands.Feedback.Services
             }
 
             var dm = getUserDM.Entity;
-            return await SendContentAsync(dm.ID, contents, color, null, ct);
+            return await SendContentAsync(dm.ID, contents, color, null, options, ct);
         }
 
         /// <summary>

--- a/Samples/DiceRoller/Commands/DiceRollCommands.cs
+++ b/Samples/DiceRoller/Commands/DiceRollCommands.cs
@@ -134,7 +134,7 @@ namespace Remora.Discord.Samples.DiceRoller.Commands
             var fields = rolls.Select(kvp => new EmbedField(kvp.Key, kvp.Value.ToString(), true)).ToList();
             var embed = new Embed("Rolls", Fields: fields, Colour: _feedbackService.Theme.Success);
 
-            var replyRolls = await _feedbackService.SendContextualEmbedAsync(embed, this.CancellationToken);
+            var replyRolls = await _feedbackService.SendContextualEmbedAsync(embed, ct: this.CancellationToken);
 
             return !replyRolls.IsSuccess
                 ? Result.FromError(replyRolls)

--- a/Samples/SlashCommands/Commands/HttpCatCommands.cs
+++ b/Samples/SlashCommands/Commands/HttpCatCommands.cs
@@ -95,7 +95,7 @@ namespace Remora.Discord.Samples.SlashCommands.Commands
             var embedImage = new EmbedImage($"https://http.cat/{httpCode}");
             var embed = new Embed(Colour: _feedbackService.Theme.Secondary, Image: embedImage);
 
-            var reply = await _feedbackService.SendContextualEmbedAsync(embed, this.CancellationToken);
+            var reply = await _feedbackService.SendContextualEmbedAsync(embed, ct: this.CancellationToken);
 
             return !reply.IsSuccess
                 ? Result.FromError(reply)
@@ -116,7 +116,7 @@ namespace Remora.Discord.Samples.SlashCommands.Commands
             var embedImage = new EmbedImage($"https://http.cat/{httpCode}");
             var embed = new Embed(Colour: _feedbackService.Theme.Secondary, Image: embedImage);
 
-            var reply = await _feedbackService.SendContextualEmbedAsync(embed, this.CancellationToken);
+            var reply = await _feedbackService.SendContextualEmbedAsync(embed, ct: this.CancellationToken);
 
             return !reply.IsSuccess
                 ? Result.FromError(reply)


### PR DESCRIPTION
Added a `FeedbackMessageOptions` record and implemented support for it in the `FeedbackService`. This allows setting the following additional options common to both normal and interaction response messages when using the `FeedbackService`:

- `IsTTS`
- `File`
- `AllowedMentions`
- `MessageComponents`

There is a slight breaking change in that existing consumers of some methods will need to explicitly name the cancellation token parameter, e.g.

```csharp
-- SendContextualEmbedAsync(Embed embed, CancellationToken ct = default)
-- await SendContextualEmbedAsync(embed, ct);

++ SendContextualEmbedAsync(Embed embed, FeedbackMessageOptions? options = null, CancellationToken ct = default)
++ await SendContextualEmbedAsync(embed, ct: ct);
``