### PR TITLE
Fix incorrect handling of target_application in invites API

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Gateway/Events/Invites/IInviteCreate.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Gateway/Events/Invites/IInviteCreate.cs
@@ -76,7 +76,12 @@ namespace Remora.Discord.API.Abstractions.Gateway.Events
         /// <summary>
         /// Gets the type of user target for this invite.
         /// </summary>
-        Optional<InviteTarget> TargetUserType { get; }
+        Optional<InviteTarget> TargetType { get; }
+
+        /// <summary>
+        /// Gets the embedded application this invite is for.
+        /// </summary>
+        Optional<IPartialApplication> TargetApplication { get; }
 
         /// <summary>
         /// Gets a value indicating whether the invite is temporary (invited users will be kicked on disconnect unless

--- a/Backend/Remora.Discord.API.Abstractions/API/Gateway/Events/Invites/IInviteCreate.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Gateway/Events/Invites/IInviteCreate.cs
@@ -69,14 +69,14 @@ namespace Remora.Discord.API.Abstractions.Gateway.Events
         int MaxUses { get; }
 
         /// <summary>
-        /// Gets the target user for this invite.
-        /// </summary>
-        Optional<IPartialUser> TargetUser { get; }
-
-        /// <summary>
         /// Gets the type of user target for this invite.
         /// </summary>
         Optional<InviteTarget> TargetType { get; }
+
+        /// <summary>
+        /// Gets the target user for this invite.
+        /// </summary>
+        Optional<IPartialUser> TargetUser { get; }
 
         /// <summary>
         /// Gets the embedded application this invite is for.

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Invites/IInvite.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Invites/IInvite.cs
@@ -63,9 +63,9 @@ namespace Remora.Discord.API.Abstractions.Objects
         new Optional<IPartialUser> TargetUser { get; }
 
         /// <summary>
-        /// Gets the ID of the target embedded application.
+        /// Gets the embedded application this invite is for.
         /// </summary>
-        new Optional<Snowflake> TargetApplication { get; }
+        new Optional<IPartialApplication> TargetApplication { get; }
 
         /// <summary>
         /// Gets the approximate count of online members. Only present when <see cref="TargetUser"/> is set.
@@ -106,7 +106,7 @@ namespace Remora.Discord.API.Abstractions.Objects
         Optional<IPartialUser> IPartialInvite.TargetUser => this.TargetUser;
 
         /// <inheritdoc/>
-        Optional<Snowflake> IPartialInvite.TargetApplication => this.TargetApplication;
+        Optional<IPartialApplication> IPartialInvite.TargetApplication => this.TargetApplication;
 
         /// <inheritdoc/>
         Optional<int> IPartialInvite.ApproximatePresenceCount => this.ApproximatePresenceCount;

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Invites/IPartialInvite.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Invites/IPartialInvite.cs
@@ -51,7 +51,7 @@ namespace Remora.Discord.API.Abstractions.Objects
         Optional<IPartialUser> TargetUser { get; }
 
         /// <inheritdoc cref="IInvite.TargetApplication" />
-        Optional<Snowflake> TargetApplication { get; }
+        Optional<IPartialApplication> TargetApplication { get; }
 
         /// <inheritdoc cref="IInvite.ApproximatePresenceCount" />
         Optional<int> ApproximatePresenceCount { get; }

--- a/Backend/Remora.Discord.API/API/Gateway/Events/Invites/InviteCreate.cs
+++ b/Backend/Remora.Discord.API/API/Gateway/Events/Invites/InviteCreate.cs
@@ -42,7 +42,8 @@ namespace Remora.Discord.API.Gateway.Events
         TimeSpan MaxAge,
         int MaxUses,
         Optional<IPartialUser> TargetUser,
-        Optional<InviteTarget> TargetUserType,
+        Optional<InviteTarget> TargetType,
+        Optional<IPartialApplication> TargetApplication,
         bool IsTemporary,
         int Uses
     ) : IInviteCreate;

--- a/Backend/Remora.Discord.API/API/Objects/Invites/Invite.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Invites/Invite.cs
@@ -39,7 +39,7 @@ namespace Remora.Discord.API.Objects
         Optional<IUser> Inviter = default,
         Optional<InviteTarget> TargetType = default,
         Optional<IPartialUser> TargetUser = default,
-        Optional<Snowflake> TargetApplication = default,
+        Optional<IPartialApplication> TargetApplication = default,
         Optional<int> ApproximatePresenceCount = default,
         Optional<int> ApproximateMemberCount = default,
         Optional<DateTimeOffset?> ExpiresAt = default,

--- a/Backend/Remora.Discord.API/API/Objects/Invites/PartialInvite.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Invites/PartialInvite.cs
@@ -39,7 +39,7 @@ namespace Remora.Discord.API.Objects
         Optional<IUser> Inviter = default,
         Optional<InviteTarget> TargetType = default,
         Optional<IPartialUser> TargetUser = default,
-        Optional<Snowflake> TargetApplication = default,
+        Optional<IPartialApplication> TargetApplication = default,
         Optional<int> ApproximatePresenceCount = default,
         Optional<int> ApproximateMemberCount = default,
         Optional<DateTimeOffset?> ExpiresAt = default,

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/INVITE_CREATE/INVITE_CREATE.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/INVITE_CREATE/INVITE_CREATE.json
@@ -39,7 +39,7 @@
       "premium_type": 0,
       "public_flags": 0
     },
-    "target_user_type": 1,
+    "target_type": 1,
     "temporary": true,
     "uses": 1
   }


### PR DESCRIPTION
As noted in the Discord, the existing handling of invites from the API is invalid when it comes to ``target_application``. We have incorrectly typed this as a Snowflake, when in reality it is a partial application object.

You can find this definition on the Discord documentation, [here](https://discord.com/developers/docs/resources/invite#invite-object-invite-structure).

I've also gone ahead and added support for this field to the [Invite Create gateway event](https://discord.com/developers/docs/topics/gateway#invite-create), and corrected the (presumably changed?) field name, ``target_type``. Thanks to Falcon in the Discord for pointing this out.

Fixes #117.