### PR TITLE
Omittable default responders

### DIFF
--- a/Remora.Discord.Commands/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/ServiceCollectionExtensions.cs
@@ -146,14 +146,14 @@ public static class ServiceCollectionExtensions
             return serviceCollection;
         }
 
-        serviceCollection.TryAddSingleton<SlashService>();
-        serviceCollection.AddInteractionResponder();
-        serviceCollection.AddAutocompleteProvider(typeof(EnumAutocompleteProvider<>));
-
         if (useDefaultInteractionResponder)
         {
-            serviceCollection.AddResponder<AutocompleteResponder>();
+            serviceCollection.AddInteractionResponder();
         }
+
+        serviceCollection.TryAddSingleton<SlashService>();
+        serviceCollection.AddAutocompleteProvider(typeof(EnumAutocompleteProvider<>));
+        serviceCollection.AddResponder<AutocompleteResponder>();
 
         return serviceCollection;
     }

--- a/Remora.Discord.Commands/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/ServiceCollectionExtensions.cs
@@ -53,13 +53,13 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="serviceCollection">The service collection.</param>
     /// <param name="enableSlash">Whether to enable slash commands.</param>
-    /// <param name="enableDefaultCommands">Whether to add a default command responder.</param>
+    /// <param name="useDefaultCommandResponder">Whether to add a default command responder.</param>
     /// <returns>The service collection, with slash commands.</returns>
     public static IServiceCollection AddDiscordCommands
     (
         this IServiceCollection serviceCollection,
         bool enableSlash = false,
-        bool enableDefaultCommands = true
+        bool useDefaultCommandResponder = true
     )
     {
         // Add the helpers used for context injection.
@@ -115,7 +115,7 @@ public static class ServiceCollectionExtensions
 
         serviceCollection.AddCommands();
 
-        if (enableDefaultCommands)
+        if (useDefaultCommandResponder)
         {
             serviceCollection.AddCommandResponder();
         }

--- a/Remora.Discord.Commands/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/ServiceCollectionExtensions.cs
@@ -53,11 +53,13 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="serviceCollection">The service collection.</param>
     /// <param name="enableSlash">Whether to enable slash commands.</param>
+    /// <param name="enableDefaultCommands">Whether to add a default command responder.</param>
     /// <returns>The service collection, with slash commands.</returns>
     public static IServiceCollection AddDiscordCommands
     (
         this IServiceCollection serviceCollection,
-        bool enableSlash = false
+        bool enableSlash = false,
+        bool enableDefaultCommands = true
     )
     {
         // Add the helpers used for context injection.
@@ -112,7 +114,11 @@ public static class ServiceCollectionExtensions
         );
 
         serviceCollection.AddCommands();
-        serviceCollection.AddCommandResponder();
+
+        if (enableDefaultCommands)
+        {
+            serviceCollection.AddCommandResponder();
+        }
 
         serviceCollection.AddCondition<RequireContextCondition>();
         serviceCollection.AddCondition<RequireOwnerCondition>();

--- a/Remora.Discord.Commands/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/ServiceCollectionExtensions.cs
@@ -54,12 +54,14 @@ public static class ServiceCollectionExtensions
     /// <param name="serviceCollection">The service collection.</param>
     /// <param name="enableSlash">Whether to enable slash commands.</param>
     /// <param name="useDefaultCommandResponder">Whether to add a default command responder.</param>
+    /// <param name="useDefaultInteractionResponder">Whether to add a default interaction responder.</param>
     /// <returns>The service collection, with slash commands.</returns>
     public static IServiceCollection AddDiscordCommands
     (
         this IServiceCollection serviceCollection,
         bool enableSlash = false,
-        bool useDefaultCommandResponder = true
+        bool useDefaultCommandResponder = true,
+        bool useDefaultInteractionResponder = true
     )
     {
         // Add the helpers used for context injection.
@@ -146,9 +148,12 @@ public static class ServiceCollectionExtensions
 
         serviceCollection.TryAddSingleton<SlashService>();
         serviceCollection.AddInteractionResponder();
+        serviceCollection.AddAutocompleteProvider(typeof(EnumAutocompleteProvider<>));
 
-        serviceCollection.AddResponder<AutocompleteResponder>()
-            .AddAutocompleteProvider(typeof(EnumAutocompleteProvider<>));
+        if (useDefaultInteractionResponder)
+        {
+            serviceCollection.AddResponder<AutocompleteResponder>();
+        }
 
         return serviceCollection;
     }


### PR DESCRIPTION
This PR adds an additional parameter to `AddDiscordCommands`, which simply skips over adding the default `AddCommandResponder` if set to false. 

In theory this should make it easier and potentially more efficient (perhaps a micro-optimization, but optimization is optimization) to stub in a responder of the end user's choosing, with the typical use-case being guild-specific prefixes.

Not sure if I should've written a test for this or anything, given it's something so simple, but do feel free to inform me if I've done something wrong.

![thaaanks](https://cdn.discordapp.com/emojis/869349856383238184.png?size=256)