### PR TITLE
Fix channel caching on `GUILD_CREATE`

### DIFF
--- a/Backend/Remora.Discord.Caching/Services/CacheService.cs
+++ b/Backend/Remora.Discord.Caching/Services/CacheService.cs
@@ -182,13 +182,13 @@ namespace Remora.Discord.Caching.Services
                 {
                     var channelKey = KeyHelpers.CreateChannelCacheKey(channel.ID);
 
-                    if (!channel.GuildID.HasValue && channel.Type is not ChannelType.DM or ChannelType.GroupDM)
+                    if (!channel.GuildID.HasValue && channel.Type is not (ChannelType.DM or ChannelType.GroupDM))
                     {
                         if (channel is Channel record)
                         {
                             // Polyfill the instance with contextual data - bit of a cheat, but it's okay in this
                             // instance
-                            Cache(key, record with { GuildID = guild.ID });
+                            Cache(channelKey, record with { GuildID = guild.ID });
                         }
                     }
                     else


### PR DESCRIPTION
Fixed an issue where channels were being cached under the guild ID, causing cache to be constantly overwritten, and channels to not be cached correctly.

I also added parentheses to the type check, as it would cause an edge case where group DMs would be cached "incorrectly"; at least, I can't imagine that was inentional either.