### PR TITLE
Add InteractionContext#Message

### DIFF
--- a/Remora.Discord.Commands/Contexts/InteractionContext.cs
+++ b/Remora.Discord.Commands/Contexts/InteractionContext.cs
@@ -24,8 +24,6 @@ using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Rest.Core;
 
-#pragma warning disable CS1591
-
 namespace Remora.Discord.Commands.Contexts;
 
 /// <summary>
@@ -41,5 +39,6 @@ public record InteractionContext
     string Token,
     Snowflake ID,
     Snowflake ApplicationID,
-    IInteractionData Data
+    IInteractionData Data,
+    Optional<IMessage> Message
 ) : CommandContext(GuildID, ChannelID, User);

--- a/Remora.Discord.Commands/Responders/AutocompleteResponder.cs
+++ b/Remora.Discord.Commands/Responders/AutocompleteResponder.cs
@@ -152,7 +152,8 @@ public class AutocompleteResponder : IResponder<IInteractionCreate>
             gatewayEvent.Token,
             gatewayEvent.ID,
             gatewayEvent.ApplicationID,
-            data
+            data,
+            gatewayEvent.Message
         );
 
         var contextInjector = _services.GetRequiredService<ContextInjectionService>();

--- a/Remora.Discord.Commands/Responders/InteractionResponder.cs
+++ b/Remora.Discord.Commands/Responders/InteractionResponder.cs
@@ -140,7 +140,8 @@ public class InteractionResponder : IResponder<IInteractionCreate>
             gatewayEvent.Token,
             gatewayEvent.ID,
             gatewayEvent.ApplicationID,
-            interactionData
+            interactionData,
+            gatewayEvent.Message
         );
 
         // Provide the created context to any services inside this scope

--- a/Tests/Remora.Discord.Commands.Tests/ContextTests.cs
+++ b/Tests/Remora.Discord.Commands.Tests/ContextTests.cs
@@ -100,7 +100,7 @@ namespace Remora.Discord.Commands.Tests
         [Fact]
         public async Task CanExecuteCommandFromGroupThatWantsInteractionContext()
         {
-            var dummyContext = new InteractionContext(default, default, null!, default, null!, default, default, null!);
+            var dummyContext = new InteractionContext(default, default, null!, default, null!, default, default, null!, default);
             _contextInjection.Context = dummyContext;
 
             var result = await _commands.TryExecuteAsync("interaction command", _services);


### PR DESCRIPTION
Adds the `InteractionContext#Message` property. This is included in `INTERACTION_CREATE` gateway events generated by message components, and stores the message that the component was attached to.