### PR TITLE
Add DiscordSnowflake and fix Snowflake instantiation

### DIFF
--- a/Backend/Remora.Discord.API/API/DiscordSnowflake.cs
+++ b/Backend/Remora.Discord.API/API/DiscordSnowflake.cs
@@ -1,5 +1,5 @@
-//
-//  SnowflakeParser.cs
+﻿//
+//  DiscordSnowflake.cs
 //
 //  Author:
 //       Jarl Gullberg <jarl.gullberg@gmail.com>
@@ -20,31 +20,25 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-using System.Threading;
-using System.Threading.Tasks;
-using JetBrains.Annotations;
-using Remora.Commands.Parsers;
-using Remora.Commands.Results;
-using Remora.Discord.Commands.Extensions;
-using Remora.Rest.Core;
-using Remora.Results;
+using System.Diagnostics.CodeAnalysis;
+using Remora.Discord.API;
 
-namespace Remora.Discord.Commands.Parsers;
+namespace Remora.Rest.Core;
 
 /// <summary>
-/// Parses instances of <see cref="Snowflake"/>s.
+/// Contains methods for initializing a <see cref="Snowflake"/> with the <see cref="Constants.DiscordEpoch"/>.
 /// </summary>
-[PublicAPI]
-public class SnowflakeParser : AbstractTypeParser<Snowflake>
+public static class DiscordSnowflake
 {
-    /// <inheritdoc />
-    public override ValueTask<Result<Snowflake>> TryParseAsync(string value, CancellationToken ct = default)
-    {
-        return new
-        (
-            !DiscordSnowflake.TryParse(value.Unmention(), out var snowflake)
-                ? new ParsingError<Snowflake>(value)
-                : snowflake.Value
-        );
-    }
+    /// <summary>
+    /// Initialzes a new instance of a Snowflake with the Discord epoch.
+    /// </summary>
+    /// <param name="value">The snowflake value.</param>
+    /// <returns>A snowflake.</returns>
+    public static Snowflake New(ulong value)
+        => new(value, Constants.DiscordEpoch);
+
+    /// <inheritdoc cref="Snowflake.TryParse(string, out Snowflake?, ulong)"/>
+    public static bool TryParse(string value, [NotNullWhen(true)] out Snowflake? result)
+        => Snowflake.TryParse(value, out result, Constants.DiscordEpoch);
 }

--- a/Backend/Remora.Discord.Rest/API/Channels/DiscordRestChannelAPI.cs
+++ b/Backend/Remora.Discord.Rest/API/Channels/DiscordRestChannelAPI.cs
@@ -460,7 +460,7 @@ namespace Remora.Discord.Rest.API
                         (
                             (f, i) => f.Match
                             (
-                                data => new PartialAttachment(new Snowflake((ulong)i), data.Name, data.Description),
+                                data => new PartialAttachment(DiscordSnowflake.New((ulong)i), data.Name, data.Description),
                                 attachment => attachment
                             )
                         ).ToList();
@@ -673,7 +673,7 @@ namespace Remora.Discord.Rest.API
                         (
                             (f, i) => f.Match
                             (
-                                data => new PartialAttachment(new Snowflake((ulong)i), data.Name, data.Description),
+                                data => new PartialAttachment(DiscordSnowflake.New((ulong)i), data.Name, data.Description),
                                 attachment => attachment
                             )
                         ).ToList();

--- a/Backend/Remora.Discord.Rest/API/Interactions/DiscordRestInteractionAPI.cs
+++ b/Backend/Remora.Discord.Rest/API/Interactions/DiscordRestInteractionAPI.cs
@@ -73,7 +73,7 @@ namespace Remora.Discord.Rest.API
                 (
                     (f, i) => f.Match
                     (
-                        data => new PartialAttachment(new Snowflake((ulong)i), data.Name, data.Description),
+                        data => new PartialAttachment(DiscordSnowflake.New((ulong)i), data.Name, data.Description),
                         attachment => attachment
                     )
                 ).ToList();
@@ -187,7 +187,7 @@ namespace Remora.Discord.Rest.API
                         (
                             (f, i) => f.Match
                             (
-                                data => new PartialAttachment(new Snowflake((ulong)i), data.Name, data.Description),
+                                data => new PartialAttachment(DiscordSnowflake.New((ulong)i), data.Name, data.Description),
                                 attachment => attachment
                             )
                         ).ToList();
@@ -267,7 +267,7 @@ namespace Remora.Discord.Rest.API
                         (
                             (f, i) => f.Match
                             (
-                                data => new PartialAttachment(new Snowflake((ulong)i), data.Name, data.Description),
+                                data => new PartialAttachment(DiscordSnowflake.New((ulong)i), data.Name, data.Description),
                                 attachment => attachment
                             )
                         ).ToList();
@@ -359,7 +359,7 @@ namespace Remora.Discord.Rest.API
                         (
                             (f, i) => f.Match
                             (
-                                data => new PartialAttachment(new Snowflake((ulong)i), data.Name, data.Description),
+                                data => new PartialAttachment(DiscordSnowflake.New((ulong)i), data.Name, data.Description),
                                 attachment => attachment
                             )
                         ).ToList();

--- a/Backend/Remora.Discord.Rest/API/Webhooks/DiscordRestWebhookAPI.cs
+++ b/Backend/Remora.Discord.Rest/API/Webhooks/DiscordRestWebhookAPI.cs
@@ -293,7 +293,7 @@ namespace Remora.Discord.Rest.API
                         (
                             (f, i) => f.Match
                             (
-                                data => new PartialAttachment(new Snowflake((ulong)i), data.Name, data.Description),
+                                data => new PartialAttachment(DiscordSnowflake.New((ulong)i), data.Name, data.Description),
                                 attachment => attachment
                             )
                         ).ToList();
@@ -398,7 +398,7 @@ namespace Remora.Discord.Rest.API
                         (
                             (f, i) => f.Match
                             (
-                                data => new PartialAttachment(new Snowflake((ulong)i), data.Name, data.Description),
+                                data => new PartialAttachment(DiscordSnowflake.New((ulong)i), data.Name, data.Description),
                                 attachment => attachment
                             )
                         ).ToList();

--- a/Remora.Discord.Commands/Parsers/ChannelParser.cs
+++ b/Remora.Discord.Commands/Parsers/ChannelParser.cs
@@ -53,7 +53,7 @@ public class ChannelParser : AbstractTypeParser<IChannel>
     /// <inheritdoc />
     public override async ValueTask<Result<IChannel>> TryParseAsync(string value, CancellationToken ct = default)
     {
-        if (!Snowflake.TryParse(value.Unmention(), out var channelID))
+        if (!DiscordSnowflake.TryParse(value.Unmention(), out var channelID))
         {
             return new ParsingError<IChannel>(value.Unmention());
         }

--- a/Remora.Discord.Commands/Parsers/EmojiParser.cs
+++ b/Remora.Discord.Commands/Parsers/EmojiParser.cs
@@ -144,7 +144,7 @@ public class EmojiParser : AbstractTypeParser<IEmoji>
             return false;
         }
 
-        if (!Snowflake.TryParse(inputParts[^1], out var emojiID))
+        if (!DiscordSnowflake.TryParse(inputParts[^1], out var emojiID))
         {
             return false;
         }

--- a/Remora.Discord.Commands/Parsers/GuildMemberParser.cs
+++ b/Remora.Discord.Commands/Parsers/GuildMemberParser.cs
@@ -61,7 +61,7 @@ public class GuildMemberParser : AbstractTypeParser<IGuildMember>
         CancellationToken ct = default
     )
     {
-        if (!Snowflake.TryParse(value.Unmention(), out var guildMemberID))
+        if (!DiscordSnowflake.TryParse(value.Unmention(), out var guildMemberID))
         {
             return new ParsingError<IGuildMember>(value);
         }

--- a/Remora.Discord.Commands/Parsers/RoleParser.cs
+++ b/Remora.Discord.Commands/Parsers/RoleParser.cs
@@ -71,7 +71,7 @@ public class RoleParser : AbstractTypeParser<IRole>
         }
 
         var roles = getRoles.Entity;
-        if (!Snowflake.TryParse(value.Unmention(), out var roleID))
+        if (!DiscordSnowflake.TryParse(value.Unmention(), out var roleID))
         {
             // Try a name-based lookup
             var roleByName = roles.FirstOrDefault(r => r.Name.Equals(value, StringComparison.OrdinalIgnoreCase));

--- a/Remora.Discord.Commands/Parsers/UserParser.cs
+++ b/Remora.Discord.Commands/Parsers/UserParser.cs
@@ -53,7 +53,7 @@ public class UserParser : AbstractTypeParser<IUser>
     /// <inheritdoc />
     public override async ValueTask<Result<IUser>> TryParseAsync(string value, CancellationToken ct = default)
     {
-        if (!Snowflake.TryParse(value.Unmention(), out var userID))
+        if (!DiscordSnowflake.TryParse(value.Unmention(), out var userID))
         {
             return new ParsingError<IUser>(value.Unmention());
         }

--- a/Samples/Autocomplete/Program.cs
+++ b/Samples/Autocomplete/Program.cs
@@ -61,7 +61,7 @@ namespace Remora.Discord.Samples.SlashCommands
             var debugServerString = configuration.GetValue<string?>("REMORA_DEBUG_SERVER");
             if (debugServerString is not null)
             {
-                if (!Snowflake.TryParse(debugServerString, out debugServer))
+                if (!DiscordSnowflake.TryParse(debugServerString, out debugServer))
                 {
                     log.LogWarning("Failed to parse debug server from environment");
                 }

--- a/Samples/SlashCommands/Program.cs
+++ b/Samples/SlashCommands/Program.cs
@@ -61,7 +61,7 @@ namespace Remora.Discord.Samples.SlashCommands
             var debugServerString = configuration.GetValue<string?>("REMORA_DEBUG_SERVER");
             if (debugServerString is not null)
             {
-                if (!Snowflake.TryParse(debugServerString, out debugServer))
+                if (!DiscordSnowflake.TryParse(debugServerString, out debugServer))
                 {
                     log.LogWarning("Failed to parse debug server from environment");
                 }


### PR DESCRIPTION
- Introduced the `DiscordSnowflake` helper class which provides means to initialise `Snowflake` instances with the correct epoch.
- Replaced existing `Snowflake` instantiations to ensure that the correct epoch is used.