### PR TITLE
Fix Nullable MaxValue and MinValue

### DIFF
--- a/Remora.Discord.Commands/Attributes/MaxValueAttribute.cs
+++ b/Remora.Discord.Commands/Attributes/MaxValueAttribute.cs
@@ -41,43 +41,35 @@ public class MaxValueAttribute : Attribute
     /// Initializes a new instance of the <see cref="MaxValueAttribute"/> class.
     /// </summary>
     /// <param name="maxValue">The maximum value.</param>
-    public MaxValueAttribute(long? maxValue = default)
+    public MaxValueAttribute(long maxValue = default)
     {
-        this.Value = maxValue is null
-            ? default
-            : new Optional<OneOf<ulong, long, float, double>>(maxValue.Value);
+        this.Value = new Optional<OneOf<ulong, long, float, double>>(maxValue);
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MaxValueAttribute"/> class.
     /// </summary>
     /// <param name="maxValue">The maximum value.</param>
-    public MaxValueAttribute(ulong? maxValue = default)
+    public MaxValueAttribute(ulong maxValue = default)
     {
-        this.Value = maxValue is null
-            ? default
-            : new Optional<OneOf<ulong, long, float, double>>(maxValue.Value);
+        this.Value = new Optional<OneOf<ulong, long, float, double>>(maxValue);
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MaxValueAttribute"/> class.
     /// </summary>
     /// <param name="maxValue">The maximum value.</param>
-    public MaxValueAttribute(float? maxValue = default)
+    public MaxValueAttribute(float maxValue = default)
     {
-        this.Value = maxValue is null
-            ? default
-            : new Optional<OneOf<ulong, long, float, double>>(maxValue.Value);
+        this.Value = new Optional<OneOf<ulong, long, float, double>>(maxValue);
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MaxValueAttribute"/> class.
     /// </summary>
     /// <param name="maxValue">The maximum value.</param>
-    public MaxValueAttribute(double? maxValue = default)
+    public MaxValueAttribute(double maxValue = default)
     {
-        this.Value = maxValue is null
-            ? default
-            : new Optional<OneOf<ulong, long, float, double>>(maxValue.Value);
+        this.Value = new Optional<OneOf<ulong, long, float, double>>(maxValue);
     }
 }

--- a/Remora.Discord.Commands/Attributes/MinValueAttribute.cs
+++ b/Remora.Discord.Commands/Attributes/MinValueAttribute.cs
@@ -41,43 +41,35 @@ public class MinValueAttribute : Attribute
     /// Initializes a new instance of the <see cref="MinValueAttribute"/> class.
     /// </summary>
     /// <param name="minValue">The minimum value.</param>
-    public MinValueAttribute(long? minValue = default)
+    public MinValueAttribute(long minValue = default)
     {
-        this.Value = minValue is null
-            ? default
-            : new Optional<OneOf<ulong, long, float, double>>(minValue.Value);
+        this.Value = new Optional<OneOf<ulong, long, float, double>>(minValue);
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MinValueAttribute"/> class.
     /// </summary>
     /// <param name="minValue">The minimum value.</param>
-    public MinValueAttribute(ulong? minValue = default)
+    public MinValueAttribute(ulong minValue = default)
     {
-        this.Value = minValue is null
-            ? default
-            : new Optional<OneOf<ulong, long, float, double>>(minValue.Value);
+        this.Value = new Optional<OneOf<ulong, long, float, double>>(minValue);
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MinValueAttribute"/> class.
     /// </summary>
     /// <param name="minValue">The minimum value.</param>
-    public MinValueAttribute(float? minValue = default)
+    public MinValueAttribute(float minValue = default)
     {
-        this.Value = minValue is null
-            ? default
-            : new Optional<OneOf<ulong, long, float, double>>(minValue.Value);
+        this.Value = new Optional<OneOf<ulong, long, float, double>>(minValue);
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MinValueAttribute"/> class.
     /// </summary>
     /// <param name="minValue">The minimum value.</param>
-    public MinValueAttribute(double? minValue = default)
+    public MinValueAttribute(double minValue = default)
     {
-        this.Value = minValue is null
-            ? default
-            : new Optional<OneOf<ulong, long, float, double>>(minValue.Value);
+        this.Value = new Optional<OneOf<ulong, long, float, double>>(minValue);
     }
 }


### PR DESCRIPTION
This PR fixed the Nullable Attributes MaxValue and MinValue, which doesn't need to be nullable, since when its null you wouldn't use the attribute 
Furthermore, it causes ` CS0181 Attribute constructor parameter ‘min/maxValue’ has type ‘long?’, which is not a valid attribute parameter type` when using them