### PR TITLE
Support multiple command trees

### DIFF
--- a/Remora.Discord.Commands/Remora.Discord.Commands.csproj
+++ b/Remora.Discord.Commands/Remora.Discord.Commands.csproj
@@ -24,7 +24,7 @@
     <ItemGroup>
         <PackageReference Include="FuzzySharp" Version="2.0.2" />
         <PackageReference Include="Humanizer.Core" Version="2.13.14" />
-        <PackageReference Include="Remora.Commands" Version="7.2.0" />
+        <PackageReference Include="Remora.Commands" Version="8.0.0" />
         <PackageReference Include="Remora.Extensions.Options.Immutable" Version="1.0.1" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     </ItemGroup>

--- a/Remora.Discord.Commands/Services/ITreeNameResolver.cs
+++ b/Remora.Discord.Commands/Services/ITreeNameResolver.cs
@@ -1,0 +1,52 @@
+//
+//  ITreeNameResolver.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Remora.Discord.Commands.Contexts;
+using Remora.Results;
+
+namespace Remora.Discord.Commands.Services;
+
+/// <summary>
+/// Resolves appropriate tree names for command execution based on a command context.
+/// </summary>
+[PublicAPI]
+public interface ITreeNameResolver
+{
+    /// <summary>
+    /// Gets the name of the tree to run commands from, given the provided context.
+    /// </summary>
+    /// <param name="context">The command context.</param>
+    /// <param name="ct">The cancellation token for this operation.</param>
+    /// <returns>
+    /// The name of the tree to run commands from, and a boolean indicating whether the command executor may try the
+    /// default tree if no command can be executed from the named tree. Whether this actually happens is up to the
+    /// implementation.
+    /// </returns>
+    Task<Result<(string TreeName, bool AllowDefaultTree)>> GetTreeNameAsync
+    (
+        ICommandContext context,
+        CancellationToken ct = default
+    );
+}

--- a/Samples/Autocomplete/Program.cs
+++ b/Samples/Autocomplete/Program.cs
@@ -118,7 +118,9 @@ public class Program
             {
                 services
                     .AddDiscordCommands(true)
-                    .AddCommandGroup<AutocompleteCommands>()
+                    .AddCommandTree()
+                        .WithCommandGroup<AutocompleteCommands>()
+                        .Finish()
                     .AddAutocompleteProvider<DictionaryAutocompleteProvider>();
             }
         )

--- a/Samples/DiceRoller/Program.cs
+++ b/Samples/DiceRoller/Program.cs
@@ -71,7 +71,8 @@ public class Program
             {
                 services
                     .AddDiscordCommands()
-                    .AddCommandGroup<DiceRollCommands>();
+                    .AddCommandTree()
+                    .WithCommandGroup<DiceRollCommands>();
 
                 services.AddHttpClient();
             }

--- a/Samples/Interactivity/Program.cs
+++ b/Samples/Interactivity/Program.cs
@@ -121,7 +121,9 @@ public class Program
             {
                 services
                     .AddDiscordCommands(true)
-                    .AddCommandGroup<InteractiveCommands>()
+                    .AddCommandTree()
+                        .WithCommandGroup<InteractiveCommands>()
+                        .Finish()
                     .AddInteractivity()
                     .AddPagination()
                     .AddInteractiveEntity<ColourDropdownEntity>();

--- a/Samples/SlashCommands/Program.cs
+++ b/Samples/SlashCommands/Program.cs
@@ -118,7 +118,8 @@ public class Program
             {
                 services
                     .AddDiscordCommands(true)
-                    .AddCommandGroup<HttpCatCommands>();
+                    .AddCommandTree()
+                        .WithCommandGroup<HttpCatCommands>();
             }
         )
         .ConfigureLogging


### PR DESCRIPTION
This PR augments Remora.Discord.Commands in order to support multiple registered command trees.

Primarily, this means two things:

  1. Slash command registration must now be done on a tree-by-tree basis. SlashService has been updated to accept `string? treeName` where appropriate.
  2. The name of the tree to use can be selected at runtime on a per-command basis via `ITreeNameResolver`. This is a service interface that library consumers can implement and register with the service provider, through which an appropriate tree name for the current command context can be provided. Optionally, this interface also allows the implementer to indicate that they'd like the default tree to be used as a fallback in case the named tree can't execute the command. By default, no service implementing `ITreeNameResolver` is registered, and only the default unnamed tree is used.

As part of this PR, Remora.Commands has also been updated to 8.0.0. Most consumer should not notice any change, but may want to switch to the new `AddCommandTree().WithCommandGroup<T>()` syntax.