### PR TITLE
Add `RequireBotPermissionsCondition`

### DIFF
--- a/Remora.Discord.Commands/Conditions/Attributes/RequireBotDiscordPermissionsAttribute.cs
+++ b/Remora.Discord.Commands/Conditions/Attributes/RequireBotDiscordPermissionsAttribute.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Remora.Commands.Conditions;
+using Remora.Discord.API.Abstractions.Objects;
+
+namespace Remora.Discord.Commands.Conditions;
+
+/// <summary>
+/// Marks an entity as requiring a certain permission for the bot user (self/current user).
+/// </summary>
+/// <remarks>
+/// Supported entities include the following:
+///     * Command groups (which require the bot to have the specified permission(s)).
+///     * Commands (which require the bot to have the specified permission(s)).
+///     * IChannels (which require the bot to have the specified permission(s) in the channel).
+/// More than one permission may be specified, in which case the behaviour is controlled with
+/// <see cref="Operator"/>.
+/// </remarks>
+[PublicAPI]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Parameter)]
+public class RequireBotDiscordPermissionsAttribute : ConditionAttribute
+{
+    /// <summary>
+    /// Gets the logical operator used to combine the permissions.
+    /// </summary>
+    public LogicalOperator Operator { get; init; } = LogicalOperator.And;
+
+    /// <summary>
+    /// Gets the permissions that should be checked.
+    /// </summary>
+    public IReadOnlyList<DiscordPermission> Permissions { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequireBotDiscordPermissionsAttribute"/> class.
+    /// </summary>
+    /// <param name="permissions">The permissions to require.</param>
+    public RequireBotDiscordPermissionsAttribute(params DiscordPermission[] permissions)
+    {
+        this.Permissions = permissions;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequireBotDiscordPermissionsAttribute"/> class.
+    /// </summary>
+    /// <param name="permissions">The permissions to require.</param>
+    public RequireBotDiscordPermissionsAttribute(params DiscordTextPermission[] permissions)
+    {
+        this.Permissions = permissions.Cast<DiscordPermission>().ToArray();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequireBotDiscordPermissionsAttribute"/> class.
+    /// </summary>
+    /// <param name="permissions">The permissions to require.</param>
+    public RequireBotDiscordPermissionsAttribute(params DiscordVoicePermission[] permissions)
+    {
+        this.Permissions = permissions.Cast<DiscordPermission>().ToArray();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequireBotDiscordPermissionsAttribute"/> class.
+    /// </summary>
+    /// <param name="permissions">The permissions to require.</param>
+    public RequireBotDiscordPermissionsAttribute(params DiscordStagePermission[] permissions)
+    {
+        this.Permissions = permissions.Cast<DiscordPermission>().ToArray();
+    }
+}

--- a/Remora.Discord.Commands/Conditions/Attributes/RequireBotDiscordPermissionsAttribute.cs
+++ b/Remora.Discord.Commands/Conditions/Attributes/RequireBotDiscordPermissionsAttribute.cs
@@ -1,3 +1,25 @@
+//
+//  RequireBotDiscordPermissionsAttribute.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Remora.Discord.Commands/Conditions/RequireBotDiscordPermissionsCondition.cs
+++ b/Remora.Discord.Commands/Conditions/RequireBotDiscordPermissionsCondition.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Remora.Commands.Conditions;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.API.Abstractions.Rest;
+using Remora.Discord.API.Objects;
+using Remora.Discord.Commands.Contexts;
+using Remora.Discord.Commands.Results;
+using Remora.Results;
+
+namespace Remora.Discord.Commands.Conditions;
+
+public class RequireBotDiscordPermissionsCondition :
+    ICondition<RequireBotDiscordPermissionsAttribute>,
+    ICondition<RequireBotDiscordPermissionsAttribute, IChannel>
+{
+    private readonly IDiscordRestUserAPI _userAPI;
+    private readonly IDiscordRestGuildAPI _guildAPI;
+    private readonly IDiscordRestChannelAPI _channelAPI;
+    private readonly ICommandContext _context;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequireBotDiscordPermissionsCondition"/> class.
+    /// </summary>
+    /// <param name="userAPI">The user API.</param>
+    /// <param name="guildAPI">The guild API.</param>
+    /// <param name="channelAPI">The channel API.</param>
+    /// <param name="context">The command context.</param>
+    public RequireBotDiscordPermissionsCondition
+    (
+        IDiscordRestUserAPI userAPI,
+        IDiscordRestGuildAPI guildAPI,
+        IDiscordRestChannelAPI channelAPI,
+        ICommandContext context
+    )
+    {
+        _userAPI = userAPI;
+        _guildAPI = guildAPI;
+        _channelAPI = channelAPI;
+        _context = context;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<Result> CheckAsync(RequireBotDiscordPermissionsAttribute attribute, CancellationToken ct = default)
+    {
+        if (!_context.GuildID.IsDefined())
+        {
+            return new PermissionDeniedError
+            (
+                "Commands executed outside of guilds may not require any permissions."
+            );
+        }
+
+        var getChannel = await _channelAPI.GetChannelAsync(_context.ChannelID);
+
+        if (!getChannel.IsSuccess)
+        {
+            return Result.FromError(getChannel);
+        }
+
+        var channel = getChannel.Entity;
+
+        return await CheckAsync(attribute, channel, ct);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<Result> CheckAsync
+    (
+        RequireBotDiscordPermissionsAttribute attribute,
+        IChannel data,
+        CancellationToken ct = default
+    )
+    {
+        if (!_context.GuildID.IsDefined(out var guildID))
+        {
+            return new PermissionDeniedError
+            (
+                "Commands executed outside of guilds may not require any permissions."
+            );
+        }
+
+        var getRoles = await _guildAPI.GetGuildRolesAsync(guildID, ct);
+
+        if (!getRoles.IsSuccess)
+        {
+            return Result.FromError(getRoles);
+        }
+
+        var guildRoles = getRoles.Entity;
+
+        var getUser = await _userAPI.GetCurrentUserAsync(ct);
+
+        if (!getUser.IsSuccess)
+        {
+            return Result.FromError(getUser);
+        }
+
+        var user = getUser.Entity;
+
+        var getMember = await _guildAPI.GetGuildMemberAsync(guildID, user.ID, ct);
+
+        if (!getMember.IsSuccess)
+        {
+            return Result.FromError(getMember);
+        }
+
+        var everyoneRole = guildRoles.First(x => x.ID == guildID);
+
+        var member = getMember.Entity;
+        var memberRoles = guildRoles.Where(r => member.Roles.Contains(r.ID)).ToArray();
+
+        var channelOverwrites = data.PermissionOverwrites.IsDefined(out var overwrites)
+            ? overwrites
+            : Array.Empty<IPermissionOverwrite>();
+
+        var computedPermissions = DiscordPermissionSet.ComputePermissions
+        (
+            user.ID,
+            everyoneRole,
+            memberRoles,
+            channelOverwrites
+        );
+
+        if (computedPermissions.HasPermission(DiscordPermission.Administrator))
+        {
+            // Always allowed.
+            return Result.FromSuccess();
+        }
+
+        var permissionInformation = attribute.Permissions
+            .Distinct()
+            .ToDictionary
+            (
+                p => p,
+                p => computedPermissions.HasPermission(p)
+            );
+
+        var result = CheckRequirements(permissionInformation, attribute.Operator);
+        if (result.IsSuccess)
+        {
+            return result;
+        }
+
+        if (result.Error is PermissionDeniedError permissionDeniedError)
+        {
+            return permissionDeniedError with
+            {
+                Message = $"The given role does not fulfill the permission requirements " +
+                          $"({Explain(permissionInformation, attribute.Operator)})."
+            };
+        }
+
+        return result;
+    }
+
+    private string Explain
+    (
+        IReadOnlyDictionary<DiscordPermission, bool> permissionInformation,
+        LogicalOperator logicalOperator
+    )
+    {
+        return logicalOperator switch
+        {
+            LogicalOperator.Not =>
+                $"had disallowed permissions {string.Join(", ", permissionInformation.Where(kvp => kvp.Value).Select(kvp => kvp.Key.ToString()))}",
+            LogicalOperator.And =>
+                $"missing permissions {string.Join(", ", permissionInformation.Where(kvp => !kvp.Value).Select(kvp => kvp.Key.ToString()))}",
+            LogicalOperator.Or =>
+                $"missing one of {string.Join(", ", permissionInformation.Keys.Select(k => k.ToString()))}",
+            LogicalOperator.Xor =>
+                $"had {string.Join(", ", permissionInformation.Where(kvp => !kvp.Value).Select(kvp => kvp.Key.ToString()))}; only one is allowed",
+            _ => throw new ArgumentOutOfRangeException(nameof(logicalOperator), logicalOperator, null)
+        };
+    }
+
+    private Result CheckRequirements
+    (
+        IReadOnlyDictionary<DiscordPermission, bool> permissionInformation,
+        LogicalOperator logicalOperator
+    )
+    {
+        var passesCheck = logicalOperator switch
+        {
+            LogicalOperator.Not => permissionInformation.Values.All(v => !v),
+            LogicalOperator.And => permissionInformation.Values.All(v => v),
+            LogicalOperator.Or => permissionInformation.Values.Any(v => v),
+            LogicalOperator.Xor => permissionInformation.Values.Aggregate
+            (
+                false,
+                (current, value) => current ^ value
+            ),
+            _ => throw new ArgumentOutOfRangeException()
+        };
+
+        return passesCheck
+            ? Result.FromSuccess()
+            : new PermissionDeniedError(Permissions: permissionInformation.Keys.ToArray());
+    }
+}

--- a/Remora.Discord.Commands/Conditions/RequireBotDiscordPermissionsCondition.cs
+++ b/Remora.Discord.Commands/Conditions/RequireBotDiscordPermissionsCondition.cs
@@ -81,7 +81,7 @@ public class RequireBotDiscordPermissionsCondition :
             );
         }
 
-        var getChannel = await _channelAPI.GetChannelAsync(_context.ChannelID);
+        var getChannel = await _channelAPI.GetChannelAsync(_context.ChannelID, ct);
 
         if (!getChannel.IsSuccess)
         {

--- a/Remora.Discord.Commands/Conditions/RequireBotDiscordPermissionsCondition.cs
+++ b/Remora.Discord.Commands/Conditions/RequireBotDiscordPermissionsCondition.cs
@@ -1,8 +1,31 @@
+//
+//  RequireBotDiscordPermissionsCondition.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Remora.Commands.Conditions;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Abstractions.Rest;
@@ -13,6 +36,10 @@ using Remora.Results;
 
 namespace Remora.Discord.Commands.Conditions;
 
+/// <summary>
+/// Determines whether the bot fulfills a set of requirements related to Discord permissions.
+/// </summary>
+[PublicAPI]
 public class RequireBotDiscordPermissionsCondition :
     ICondition<RequireBotDiscordPermissionsAttribute>,
     ICondition<RequireBotDiscordPermissionsAttribute, IChannel>
@@ -148,7 +175,7 @@ public class RequireBotDiscordPermissionsCondition :
         {
             return permissionDeniedError with
             {
-                Message = $"The given role does not fulfill the permission requirements " +
+                Message = $"The given channel does not fulfill the permission requirements " +
                           $"({Explain(permissionInformation, attribute.Operator)})."
             };
         }

--- a/Remora.Discord.Commands/Conditions/RequireDiscordPermissionCondition.cs
+++ b/Remora.Discord.Commands/Conditions/RequireDiscordPermissionCondition.cs
@@ -46,7 +46,6 @@ public class RequireDiscordPermissionCondition :
     ICondition<RequireDiscordPermissionAttribute, IGuildMember>,
     ICondition<RequireDiscordPermissionAttribute, IRole>
 {
-    private readonly IDiscordRestUserAPI _userAPI;
     private readonly IDiscordRestGuildAPI _guildAPI;
     private readonly IDiscordRestChannelAPI _channelAPI;
     private readonly ICommandContext _context;
@@ -54,19 +53,16 @@ public class RequireDiscordPermissionCondition :
     /// <summary>
     /// Initializes a new instance of the <see cref="RequireDiscordPermissionCondition"/> class.
     /// </summary>
-    /// <param name="userAPI">The user API.</param>
     /// <param name="guildAPI">The guild API.</param>
     /// <param name="channelAPI">The channel API.</param>
     /// <param name="context">The command context.</param>
     public RequireDiscordPermissionCondition
     (
-        IDiscordRestUserAPI userAPI,
         IDiscordRestGuildAPI guildAPI,
         IDiscordRestChannelAPI channelAPI,
         ICommandContext context
     )
     {
-        _userAPI = userAPI;
         _guildAPI = guildAPI;
         _channelAPI = channelAPI;
         _context = context;

--- a/Tests/Remora.Discord.Commands.Tests/Conditions/RequireBotPermissionsConditionTests.Cases.And.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Conditions/RequireBotPermissionsConditionTests.Cases.And.cs
@@ -1,0 +1,113 @@
+//
+//  RequireBotPermissionsConditionTests.Cases.And.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.Commands.Conditions;
+
+namespace Remora.Discord.Commands.Tests.Conditions;
+
+public partial class RequireBotPermissionsConditionTests
+{
+    /// <summary>
+    /// Produces a set of test cases for the <see cref="LogicalOperator.And"/> operator.
+    /// </summary>
+    /// <returns>The test cases.</returns>
+    private static IEnumerable<object[]> AndCases()
+    {
+        var a = DiscordPermission.SendMessages;
+        var b = DiscordPermission.ReadMessageHistory;
+        var c = DiscordPermission.EmbedLinks;
+
+        yield return new object[]
+        {
+            LogicalOperator.And,
+            new[] { a },
+            new[] { a },
+            true
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.And,
+            new[] { a },
+            new[] { b },
+            false
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.And,
+            new[] { a },
+            new[] { a, b },
+            true
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.And,
+            new[] { a },
+            new[] { b, c },
+            false
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.And,
+            new[] { a, b },
+            new[] { a, b },
+            true
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.And,
+            new[] { a, b },
+            new[] { a, c },
+            false
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.And,
+            new[] { a, b },
+            new[] { a },
+            false
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.And,
+            new[] { a, b },
+            new[] { b },
+            false
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.And,
+            new[] { a, b },
+            new[] { c },
+            false
+        };
+    }
+}

--- a/Tests/Remora.Discord.Commands.Tests/Conditions/RequireBotPermissionsConditionTests.Cases.Not.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Conditions/RequireBotPermissionsConditionTests.Cases.Not.cs
@@ -1,0 +1,109 @@
+//
+//  RequireBotPermissionsConditionTests.Cases.Not.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.Commands.Conditions;
+
+namespace Remora.Discord.Commands.Tests.Conditions;
+
+public partial class RequireBotPermissionsConditionTests
+{
+    private static IEnumerable<object[]> NotCases()
+    {
+        var a = DiscordPermission.SendMessages;
+        var b = DiscordPermission.ReadMessageHistory;
+        var c = DiscordPermission.EmbedLinks;
+
+        yield return new object[]
+        {
+            LogicalOperator.Not,
+            new[] { a },
+            new[] { a },
+            false
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Not,
+            new[] { a },
+            new[] { b },
+            true
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Not,
+            new[] { a },
+            new[] { a, b },
+            false
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Not,
+            new[] { a },
+            new[] { b, c },
+            true
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Not,
+            new[] { a, b },
+            new[] { a, b },
+            false
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Not,
+            new[] { a, b },
+            new[] { a, c },
+            false
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Not,
+            new[] { a, b },
+            new[] { a },
+            false
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Not,
+            new[] { a, b },
+            new[] { b },
+            false
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Not,
+            new[] { a, b },
+            new[] { c },
+            true
+        };
+    }
+}

--- a/Tests/Remora.Discord.Commands.Tests/Conditions/RequireBotPermissionsConditionTests.Cases.Or.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Conditions/RequireBotPermissionsConditionTests.Cases.Or.cs
@@ -1,0 +1,109 @@
+//
+//  RequireBotPermissionsConditionTests.Cases.Or.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.Commands.Conditions;
+
+namespace Remora.Discord.Commands.Tests.Conditions;
+
+public partial class RequireBotPermissionsConditionTests
+{
+    private static IEnumerable<object[]> OrCases()
+    {
+        var a = DiscordPermission.SendMessages;
+        var b = DiscordPermission.ReadMessageHistory;
+        var c = DiscordPermission.EmbedLinks;
+
+        yield return new object[]
+        {
+            LogicalOperator.Or,
+            new[] { a },
+            new[] { a },
+            true
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Or,
+            new[] { a },
+            new[] { b },
+            false
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Or,
+            new[] { a },
+            new[] { a, b },
+            true
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Or,
+            new[] { a },
+            new[] { b, c },
+            false
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Or,
+            new[] { a, b },
+            new[] { a, b },
+            true
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Or,
+            new[] { a, b },
+            new[] { a, c },
+            true
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Or,
+            new[] { a, b },
+            new[] { a },
+            true
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Or,
+            new[] { a, b },
+            new[] { b },
+            true
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Or,
+            new[] { a, b },
+            new[] { c },
+            false
+        };
+    }
+}

--- a/Tests/Remora.Discord.Commands.Tests/Conditions/RequireBotPermissionsConditionTests.Cases.Xor.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Conditions/RequireBotPermissionsConditionTests.Cases.Xor.cs
@@ -1,0 +1,109 @@
+//
+//  RequireBotPermissionsConditionTests.Cases.Xor.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.Commands.Conditions;
+
+namespace Remora.Discord.Commands.Tests.Conditions;
+
+public partial class RequireBotPermissionsConditionTests
+{
+    private static IEnumerable<object[]> XorCases()
+    {
+        var a = DiscordPermission.SendMessages;
+        var b = DiscordPermission.ReadMessageHistory;
+        var c = DiscordPermission.EmbedLinks;
+
+        yield return new object[]
+        {
+            LogicalOperator.Xor,
+            new[] { a },
+            new[] { a },
+            true
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Xor,
+            new[] { a },
+            new[] { b },
+            false
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Xor,
+            new[] { a },
+            new[] { a, b },
+            true
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Xor,
+            new[] { a },
+            new[] { b, c },
+            false
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Xor,
+            new[] { a, b },
+            new[] { a, b },
+            false
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Xor,
+            new[] { a, b },
+            new[] { a, c },
+            true
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Xor,
+            new[] { a, b },
+            new[] { a },
+            true
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Xor,
+            new[] { a, b },
+            new[] { b },
+            true
+        };
+
+        yield return new object[]
+        {
+            LogicalOperator.Xor,
+            new[] { a, b },
+            new[] { c },
+            false
+        };
+    }
+}

--- a/Tests/Remora.Discord.Commands.Tests/Conditions/RequireBotPermissionsConditionTests.Cases.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Conditions/RequireBotPermissionsConditionTests.Cases.cs
@@ -1,0 +1,57 @@
+//
+//  RequireBotPermissionsConditionTests.Cases.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+
+namespace Remora.Discord.Commands.Tests.Conditions;
+
+public partial class RequireBotPermissionsConditionTests
+{
+    /// <summary>
+    /// Gets the test cases.
+    /// </summary>
+    public static IEnumerable<object[]> Cases
+    {
+        get
+        {
+            foreach (var andCase in AndCases())
+            {
+                yield return andCase;
+            }
+
+            foreach (var orCases in OrCases())
+            {
+                yield return orCases;
+            }
+
+            foreach (var xorCase in XorCases())
+            {
+                yield return xorCase;
+            }
+
+            foreach (var notCase in NotCases())
+            {
+                yield return notCase;
+            }
+        }
+    }
+}

--- a/Tests/Remora.Discord.Commands.Tests/Conditions/RequireBotPermissionsConditionTests.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Conditions/RequireBotPermissionsConditionTests.cs
@@ -1,0 +1,318 @@
+//
+//  RequireBotPermissionsConditionTests.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Remora.Discord.API;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.API.Abstractions.Rest;
+using Remora.Discord.API.Objects;
+using Remora.Discord.Commands.Conditions;
+using Remora.Discord.Commands.Contexts;
+using Remora.Discord.Tests;
+using Remora.Rest.Core;
+using Remora.Results;
+using Xunit;
+
+namespace Remora.Discord.Commands.Tests.Conditions;
+
+/// <summary>
+/// Tests the <see cref="Remora.Discord.Commands.Conditions.RequireBotDiscordPermissionsCondition"/> class.
+/// </summary>
+public partial class RequireBotPermissionsConditionTests
+{
+    private readonly Mock<IDiscordRestUserAPI> _userAPIMock;
+    private readonly Mock<IDiscordRestGuildAPI> _guildAPIMock;
+    private readonly Mock<IDiscordRestChannelAPI> _channelAPIMock;
+    private readonly Mock<ICommandContext> _contextMock;
+    private readonly Mock<IRole> _everyoneRoleMock;
+    private readonly Mock<IUser> _userMock;
+    private readonly Mock<IGuildMember> _memberMock;
+    private readonly Snowflake _guildID;
+    private readonly Mock<IChannel> _channelMock;
+    private readonly Snowflake _userID;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequireBotPermissionsConditionTests"/> class.
+    /// </summary>
+    public RequireBotPermissionsConditionTests()
+    {
+        _guildID = DiscordSnowflake.New(0);
+        _userID = DiscordSnowflake.New(1);
+
+        var channelID = DiscordSnowflake.New(2);
+
+        // Dependency mocks
+        _userAPIMock = new Mock<IDiscordRestUserAPI>();
+        _guildAPIMock = new Mock<IDiscordRestGuildAPI>();
+        _channelAPIMock = new Mock<IDiscordRestChannelAPI>();
+        _contextMock = new Mock<ICommandContext>();
+
+        // Result mocks
+        _everyoneRoleMock = new Mock<IRole>();
+        _userMock = new Mock<IUser>();
+        _memberMock = new Mock<IGuildMember>();
+        _channelMock = new Mock<IChannel>();
+
+        // Setup
+        _contextMock.Setup(c => c.User.ID).Returns(_userID);
+        _contextMock.Setup(c => c.GuildID).Returns(_guildID);
+        _contextMock.Setup(c => c.ChannelID).Returns(channelID);
+
+        _channelMock.Setup(c => c.ID).Returns(channelID);
+        _channelMock
+            .Setup(c => c.PermissionOverwrites)
+            .Returns(default(Optional<IReadOnlyList<IPermissionOverwrite>>));
+
+        _everyoneRoleMock.Setup(r => r.ID).Returns(_guildID);
+
+        _userMock.Setup(u => u.ID).Returns(_userID);
+
+        _memberMock.Setup(m => m.User).Returns(new Optional<IUser>(_userMock.Object));
+        _memberMock.Setup(m => m.Roles).Returns(Array.Empty<Snowflake>());
+
+        _guildAPIMock
+            .Setup
+            (
+                a => a.GetGuildMemberAsync
+                (
+                    It.Is<Snowflake>(s => s == _guildID),
+                    It.Is<Snowflake>(s => s == _userID),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(Result<IGuildMember>.FromSuccess(_memberMock.Object));
+
+        _guildAPIMock
+            .Setup
+            (
+                a => a.GetGuildRolesAsync(It.Is<Snowflake>(s => s == _guildID), It.IsAny<CancellationToken>())
+            )
+            .ReturnsAsync(new[] { _everyoneRoleMock.Object });
+
+        _channelAPIMock
+            .Setup(a => a.GetChannelAsync(It.Is<Snowflake>(s => s == channelID), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IChannel>.FromSuccess(_channelMock.Object));
+
+        _userAPIMock
+            .Setup(u => u.GetCurrentUserAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<IUser>.FromSuccess(_userMock.Object));
+    }
+
+    /// <summary>
+    /// Tests whether the condition respects the administrator permission.
+    /// </summary>
+    /// <typeparam name="TPermission">The required permissions.</typeparam>
+    /// <param name="logicalOperator">The logical operator to apply.</param>
+    /// <param name="required">The permissions required by the condition.</param>
+    /// <param name="effectivePermissions">The effective permissions.</param>
+    /// <param name="expected">The expected result.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public async Task RespectsAdministratorPermission<TPermission>
+    (
+        LogicalOperator logicalOperator,
+        TPermission[] required,
+        DiscordPermission[] effectivePermissions,
+        bool expected
+    )
+        where TPermission : struct, Enum
+    {
+        _ = expected;
+
+        effectivePermissions = effectivePermissions.Concat(new[] { DiscordPermission.Administrator }).ToArray();
+
+        _everyoneRoleMock.Setup(r => r.Permissions).Returns(new DiscordPermissionSet(effectivePermissions));
+
+        var requiredPermissions = required.Cast<DiscordPermission>().ToArray();
+        var attribute = new RequireBotDiscordPermissionsAttribute(requiredPermissions)
+        {
+            Operator = logicalOperator
+        };
+
+        var condition = new RequireBotDiscordPermissionsCondition
+        (
+            _userAPIMock.Object,
+            _guildAPIMock.Object,
+            _channelAPIMock.Object,
+            _contextMock.Object
+        );
+
+        var result = await condition.CheckAsync(attribute);
+        ResultAssert.Successful(result);
+    }
+
+    /// <summary>
+    /// Tests whether the condition acknowledges and correctly evaluates role permissions.
+    /// </summary>
+    /// <typeparam name="TPermission">The required permissions.</typeparam>
+    /// <param name="logicalOperator">The logical operator to apply.</param>
+    /// <param name="required">The permissions required by the condition.</param>
+    /// <param name="effectivePermissions">The effective permissions.</param>
+    /// <param name="expected">The expected result.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public async Task ReturnsCorrectResultForRolePermissions<TPermission>
+    (
+        LogicalOperator logicalOperator,
+        TPermission[] required,
+        DiscordPermission[] effectivePermissions,
+        bool expected
+    )
+        where TPermission : struct, Enum
+    {
+        _everyoneRoleMock.Setup(r => r.Permissions).Returns(new DiscordPermissionSet(effectivePermissions));
+
+        var requiredPermissions = required.Cast<DiscordPermission>().ToArray();
+        var attribute = new RequireBotDiscordPermissionsAttribute(requiredPermissions)
+        {
+            Operator = logicalOperator
+        };
+
+        var condition = new RequireBotDiscordPermissionsCondition
+            (
+                _userAPIMock.Object,
+                _guildAPIMock.Object,
+                _channelAPIMock.Object,
+                _contextMock.Object
+            );
+
+        var result = await condition.CheckAsync(attribute);
+
+        Assert.Equal(expected, result.IsSuccess);
+    }
+
+    /// <summary>
+    /// Tests whether the condition acknowledges and correctly evaluates channel overwrites.
+    /// </summary>
+    /// <typeparam name="TPermission">The required permissions.</typeparam>
+    /// <param name="logicalOperator">The logical operator to apply.</param>
+    /// <param name="required">The permissions required by the condition.</param>
+    /// <param name="effectivePermissions">The effective permissions.</param>
+    /// <param name="expected">The expected result.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public async Task ReturnsCorrectResultForChannelRoleOverwrite<TPermission>
+    (
+        LogicalOperator logicalOperator,
+        TPermission[] required,
+        DiscordPermission[] effectivePermissions,
+        bool expected
+    )
+        where TPermission : struct, Enum
+    {
+        _everyoneRoleMock.Setup(r => r.Permissions).Returns(new DiscordPermissionSet(BigInteger.Zero));
+
+        _channelMock
+            .Setup(c => c.PermissionOverwrites)
+            .Returns(new[]
+            {
+                new PermissionOverwrite
+                (
+                    _everyoneRoleMock.Object.ID,
+                    PermissionOverwriteType.Role,
+                    new DiscordPermissionSet(effectivePermissions),
+                    new DiscordPermissionSet(BigInteger.Zero)
+                )
+            });
+
+        var requiredPermissions = required.Cast<DiscordPermission>().ToArray();
+        var attribute = new RequireBotDiscordPermissionsAttribute(requiredPermissions)
+        {
+            Operator = logicalOperator
+        };
+
+        var condition = new RequireBotDiscordPermissionsCondition
+        (
+            _userAPIMock.Object,
+            _guildAPIMock.Object,
+            _channelAPIMock.Object,
+            _contextMock.Object
+        );
+
+        var result = await condition.CheckAsync(attribute);
+
+        Assert.Equal(expected, result.IsSuccess);
+    }
+
+    /// <summary>
+    /// Tests whether the condition acknowledges and correctly evaluates user overwrites.
+    /// </summary>
+    /// <typeparam name="TPermission">The required permissions.</typeparam>
+    /// <param name="logicalOperator">The logical operator to apply.</param>
+    /// <param name="required">The permissions required by the condition.</param>
+    /// <param name="effectivePermissions">The effective permissions.</param>
+    /// <param name="expected">The expected result.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public async Task ReturnsCorrectResultForChannelMemberOverwrite<TPermission>
+    (
+        LogicalOperator logicalOperator,
+        TPermission[] required,
+        DiscordPermission[] effectivePermissions,
+        bool expected
+    )
+        where TPermission : struct, Enum
+    {
+        _everyoneRoleMock.Setup(r => r.Permissions).Returns(new DiscordPermissionSet(BigInteger.Zero));
+
+        _channelMock
+            .Setup(c => c.PermissionOverwrites)
+            .Returns(new[]
+            {
+                new PermissionOverwrite
+                (
+                    _userID,
+                    PermissionOverwriteType.Member,
+                    new DiscordPermissionSet(effectivePermissions),
+                    new DiscordPermissionSet(BigInteger.Zero)
+                )
+            });
+
+        var requiredPermissions = required.Cast<DiscordPermission>().ToArray();
+        var attribute = new RequireBotDiscordPermissionsAttribute(requiredPermissions)
+        {
+            Operator = logicalOperator
+        };
+
+        var condition = new RequireBotDiscordPermissionsCondition
+        (
+            _userAPIMock.Object,
+            _guildAPIMock.Object,
+            _channelAPIMock.Object,
+            _contextMock.Object
+        );
+
+        var result = await condition.CheckAsync(attribute);
+
+        Assert.Equal(expected, result.IsSuccess);
+    }
+}

--- a/Tests/Remora.Discord.Commands.Tests/Conditions/RequireDiscordPermissionConditionTests.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Conditions/RequireDiscordPermissionConditionTests.cs
@@ -44,7 +44,6 @@ namespace Remora.Discord.Commands.Tests.Conditions;
 /// </summary>
 public partial class RequireDiscordPermissionConditionTests
 {
-    private readonly Mock<IDiscordRestUserAPI> _userAPIMock;
     private readonly Mock<IDiscordRestGuildAPI> _guildAPIMock;
     private readonly Mock<IDiscordRestChannelAPI> _channelAPIMock;
     private readonly Mock<ICommandContext> _contextMock;
@@ -66,7 +65,6 @@ public partial class RequireDiscordPermissionConditionTests
         var channelID = DiscordSnowflake.New(2);
 
         // Dependency mocks
-        _userAPIMock = new Mock<IDiscordRestUserAPI>();
         _guildAPIMock = new Mock<IDiscordRestGuildAPI>();
         _channelAPIMock = new Mock<IDiscordRestChannelAPI>();
         _contextMock = new Mock<ICommandContext>();
@@ -148,7 +146,6 @@ public partial class RequireDiscordPermissionConditionTests
 
         var condition = new RequireDiscordPermissionCondition
         (
-            _userAPIMock.Object,
             _guildAPIMock.Object,
             _channelAPIMock.Object,
             _contextMock.Object
@@ -188,7 +185,6 @@ public partial class RequireDiscordPermissionConditionTests
 
         var condition = new RequireDiscordPermissionCondition
         (
-            _userAPIMock.Object,
             _guildAPIMock.Object,
             _channelAPIMock.Object,
             _contextMock.Object
@@ -228,7 +224,6 @@ public partial class RequireDiscordPermissionConditionTests
 
         var condition = new RequireDiscordPermissionCondition
         (
-            _userAPIMock.Object,
             _guildAPIMock.Object,
             _channelAPIMock.Object,
             _contextMock.Object
@@ -268,7 +263,6 @@ public partial class RequireDiscordPermissionConditionTests
 
         var condition = new RequireDiscordPermissionCondition
         (
-            _userAPIMock.Object,
             _guildAPIMock.Object,
             _channelAPIMock.Object,
             _contextMock.Object
@@ -312,7 +306,6 @@ public partial class RequireDiscordPermissionConditionTests
 
         var condition = new RequireDiscordPermissionCondition
         (
-            _userAPIMock.Object,
             _guildAPIMock.Object,
             _channelAPIMock.Object,
             _contextMock.Object
@@ -354,7 +347,6 @@ public partial class RequireDiscordPermissionConditionTests
 
         var condition = new RequireDiscordPermissionCondition
         (
-            _userAPIMock.Object,
             _guildAPIMock.Object,
             _channelAPIMock.Object,
             _contextMock.Object
@@ -397,7 +389,6 @@ public partial class RequireDiscordPermissionConditionTests
 
         var condition = new RequireDiscordPermissionCondition
         (
-            _userAPIMock.Object,
             _guildAPIMock.Object,
             _channelAPIMock.Object,
             _contextMock.Object
@@ -440,7 +431,6 @@ public partial class RequireDiscordPermissionConditionTests
 
         var condition = new RequireDiscordPermissionCondition
         (
-            _userAPIMock.Object,
             _guildAPIMock.Object,
             _channelAPIMock.Object,
             _contextMock.Object
@@ -488,7 +478,6 @@ public partial class RequireDiscordPermissionConditionTests
 
         var condition = new RequireDiscordPermissionCondition
         (
-            _userAPIMock.Object,
             _guildAPIMock.Object,
             _channelAPIMock.Object,
             _contextMock.Object
@@ -536,7 +525,6 @@ public partial class RequireDiscordPermissionConditionTests
 
         var condition = new RequireDiscordPermissionCondition
         (
-            _userAPIMock.Object,
             _guildAPIMock.Object,
             _channelAPIMock.Object,
             _contextMock.Object
@@ -594,7 +582,6 @@ public partial class RequireDiscordPermissionConditionTests
 
         var condition = new RequireDiscordPermissionCondition
         (
-            _userAPIMock.Object,
             _guildAPIMock.Object,
             _channelAPIMock.Object,
             _contextMock.Object
@@ -652,7 +639,6 @@ public partial class RequireDiscordPermissionConditionTests
 
         var condition = new RequireDiscordPermissionCondition
         (
-            _userAPIMock.Object,
             _guildAPIMock.Object,
             _channelAPIMock.Object,
             _contextMock.Object

--- a/Tests/Remora.Discord.Commands.Tests/Remora.Discord.Commands.Tests.csproj
+++ b/Tests/Remora.Discord.Commands.Tests/Remora.Discord.Commands.Tests.csproj
@@ -38,6 +38,21 @@
       <Compile Update="Data\Valid\NullableTypedCommands.cs">
         <DependentUpon>TypedCommands.cs</DependentUpon>
       </Compile>
+      <Compile Update="Conditions\RequireBotPermissionsConditionTests.Cases.cs">
+        <DependentUpon>RequireBotPermissionsConditionTests.cs</DependentUpon>
+      </Compile>
+      <Compile Update="Conditions\RequireBotPermissionsConditionTests.Cases.And.cs">
+        <DependentUpon>RequireBotPermissionsConditionTests.Cases.cs</DependentUpon>
+      </Compile>
+      <Compile Update="Conditions\RequireBotPermissionsConditionTests.Cases.Not.cs">
+        <DependentUpon>RequireBotPermissionsConditionTests.Cases.cs</DependentUpon>
+      </Compile>
+      <Compile Update="Conditions\RequireBotPermissionsConditionTests.Cases.Or.cs">
+        <DependentUpon>RequireBotPermissionsConditionTests.Cases.cs</DependentUpon>
+      </Compile>
+      <Compile Update="Conditions\RequireBotPermissionsConditionTests.Cases.Xor.cs">
+        <DependentUpon>RequireBotPermissionsConditionTests.Cases.cs</DependentUpon>
+      </Compile>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adds a new condition (and attribute) that requires the bot to have certain permissions in the channel a command is invoked within.


Test to come; I have other things I'd like to PR as well.