### PR TITLE
System.Text.Json on .NET 6 should come from runtime pack.

### DIFF
--- a/Backend/Remora.Discord.API/Remora.Discord.API.csproj
+++ b/Backend/Remora.Discord.API/Remora.Discord.API.csproj
@@ -21,7 +21,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-        <PackageReference Include="System.Text.Json" Version="6.0.2" />
+        <PackageReference Include="System.Text.Json" Version="6.0.2" Condition="'$(TargetFramework)' != 'net6.0'" />
         <PackageReference Include="Remora.Rest" Version="1.2.1" />
     </ItemGroup>
 

--- a/Remora.Discord.Commands/Remora.Discord.Commands.csproj
+++ b/Remora.Discord.Commands/Remora.Discord.Commands.csproj
@@ -26,7 +26,8 @@
         <PackageReference Include="Humanizer.Core" Version="2.14.1" />
         <PackageReference Include="Remora.Commands" Version="9.0.1" />
         <PackageReference Include="Remora.Extensions.Options.Immutable" Version="1.0.2" />
-        <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+        <!-- Provided by default in .NET 6's runtime pack. As such the reference is not needed. -->
+        <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" Condition="'$(TargetFramework)' != 'net6.0'" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
S.T.J (since stable 6.0.2 is referenced here) should be ignored when targeting .NET 6. This is due to it being included in the Microsoft.NETCore.App runtime bundle which often times includes crucial bug fixes / improvements. As such if newer versions is needed, simply ensure the user's .NET SDK is updated on their end or have them do a property to override the default runtime pack version provided by the SDK).

Depends on:
- https://github.com/azambrano/JsonDocumentPath/pull/2
- https://github.com/Nihlus/Remora.Rest/pull/4