### PR TITLE
Add support for "cache dodging"

### DIFF
--- a/Backend/Remora.Discord.Caching/Services/CacheService.cs
+++ b/Backend/Remora.Discord.Caching/Services/CacheService.cs
@@ -75,7 +75,7 @@ public class CacheService
                 return;
             }
         }
-        
+
         Action cacheAction = instance switch
         {
             IWebhook webhook => () => CacheWebhook(key, webhook),

--- a/Backend/Remora.Discord.Caching/Services/CacheService.cs
+++ b/Backend/Remora.Discord.Caching/Services/CacheService.cs
@@ -68,6 +68,14 @@ public class CacheService
     public void Cache<TInstance>(object key, TInstance instance)
         where TInstance : class
     {
+        if (_cacheSettings.GetAbsoluteExpirationOrDefault(typeof(TInstance)) is var absoluteExpiration)
+        {
+            if (absoluteExpiration == TimeSpan.Zero)
+            {
+                return;
+            }
+        }
+        
         Action cacheAction = instance switch
         {
             IWebhook webhook => () => CacheWebhook(key, webhook),


### PR DESCRIPTION
There are times where you intentionally want to avoid caching certain data (such as presence data) or anything else you know you won't be using.

The default TTL of 30s is *fine*, but in the case of presence data, the events are streamed so frequently that the cache is always full of this data. 