### PR TITLE
Allow `large_threshold` to be specified

### DIFF
--- a/Backend/Remora.Discord.Gateway/DiscordGatewayClient.cs
+++ b/Backend/Remora.Discord.Gateway/DiscordGatewayClient.cs
@@ -906,10 +906,11 @@ public class DiscordGatewayClient : IDisposable
             (
                 _tokenStore.Token,
                 _gatewayOptions.ConnectionProperties,
-                Intents: _gatewayOptions.Intents,
                 Compress: false,
+                LargeThreshold: _gatewayOptions.LargeThreshold,
                 Shard: shardInformation,
-                Presence: initialPresence
+                Presence: initialPresence,
+                Intents: _gatewayOptions.Intents
             )
         );
 

--- a/Backend/Remora.Discord.Gateway/DiscordGatewayClientOptions.cs
+++ b/Backend/Remora.Discord.Gateway/DiscordGatewayClientOptions.cs
@@ -53,6 +53,15 @@ public class DiscordGatewayClientOptions
     public IConnectionProperties ConnectionProperties { get; set; } = new ConnectionProperties("Remora.Discord");
 
     /// <summary>
+    /// Gets or sets the large threshold for the gateway.
+    /// For guilds with members that exceed the threshold, offline members will be omitted.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to 50, max of 250.
+    /// </remarks>
+    public byte LargeThreshold { get; set; } = 50;
+
+    /// <summary>
     /// Gets or sets the shard identification information. This is used to connect the client as a sharded
     /// connection, where events are distributed over a set of active connections.
     /// </summary>


### PR DESCRIPTION
Allows `large_threshold` to be specified in the config. This was previously absent, and thus defaulted to 50. For consistency the default in the config is also 50, but is now adjustable