### PR TITLE
Fix unexpected/undocumented behavior when setting absolute expirations

### DIFF
--- a/Backend/Remora.Discord.Caching/Services/CacheSettings.cs
+++ b/Backend/Remora.Discord.Caching/Services/CacheSettings.cs
@@ -183,7 +183,9 @@ public class CacheSettings
         }
 
         var slidingExpiration = GetSlidingExpirationOrDefault<T>();
-        if (slidingExpiration is not null)
+
+        // See https://github.com/Nihlus/Remora.Discord/pull/165
+        if (slidingExpiration is not null && absoluteExpiration is not null)
         {
             cacheOptions.SetSlidingExpiration(slidingExpiration.Value);
         }


### PR DESCRIPTION
This is a *proper* fix, unlike what #162 was, since I've taken some time to properly investigate the root issue with this. While this is technically probably documented behavior in the BCL, both Remora's documentation and smaples are technically misleading (which is more than likely unintentionally so).

This issue is not a fault of Remora, but of deeply nested behavior in the BCL, and specifically in CacheEntry.

the tl;dr is essenitally if a sliding expiration is set, and absolute is *not*, the sliding expiration will take precedence over the absolute expiration. Joyous. 

As I said, I've done proper research into this. A link to culprit BCL code is [here](https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs#L181-L207)

Example screenshot of before this fix:

![image_1](https://cdn.velvetthepanda.dev/gF3J2.png)

And after:

![image_2](https://cdn.velvetthepanda.dev/ru8g5.png)

A bandaid fix would be to simply use `.SetDefaultSlidingExpiration` and set it to null, but I think this is a better fix as it aligns more to what people probably expect `.SetAbsoluteExpiration` does. Sliding expirations are strange and exhibit strange behavior. I'm quite against them.