### PR TITLE
Register RequireBotDiscordPermissionsCondition

### DIFF
--- a/Remora.Discord.Commands/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/ServiceCollectionExtensions.cs
@@ -129,6 +129,7 @@ public static class ServiceCollectionExtensions
         serviceCollection.AddCondition<RequireContextCondition>();
         serviceCollection.AddCondition<RequireOwnerCondition>();
         serviceCollection.AddCondition<RequireDiscordPermissionCondition>();
+        serviceCollection.AddCondition<RequireBotDiscordPermissionsCondition>();
 
         serviceCollection
             .AddParser<ChannelParser>()


### PR DESCRIPTION
In #155, I had overlooked the fact that conditions need to be registered to actually function.

This simple PR fixes that.