### PR TITLE
Parse X-RateLimit-Reset independent of system culture

### DIFF
--- a/Backend/Remora.Discord.Rest/API/RateLimitBucket.cs
+++ b/Backend/Remora.Discord.Rest/API/RateLimitBucket.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Threading;
@@ -112,7 +113,7 @@ internal class RateLimitBucket
                 return false;
             }
 
-            if (!double.TryParse(rawReset.SingleOrDefault(), out var resetsAtEpoch))
+            if (!double.TryParse(rawReset.SingleOrDefault(), NumberStyles.Float | NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var resetsAtEpoch))
             {
                 return false;
             }

--- a/Backend/Remora.Discord.Rest/API/RateLimitBucket.cs
+++ b/Backend/Remora.Discord.Rest/API/RateLimitBucket.cs
@@ -113,7 +113,7 @@ internal class RateLimitBucket
                 return false;
             }
 
-            if (!double.TryParse(rawReset.SingleOrDefault(), NumberStyles.Float | NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var resetsAtEpoch))
+            if (!double.TryParse(rawReset.SingleOrDefault(), NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var resetsAtEpoch))
             {
                 return false;
             }


### PR DESCRIPTION
The `X-RateLimit-Reset` header is currently parsed based on the systems locale.

Some locales use a `,` as decimal separator and some locales use `.` for separation.

Therefore the double must be parsed indepedent of the systems locale.