### PR TITLE
Fix typo in `CreateGuildInvitesCacheKey` by using `CreateGuildCacheKey`

### DIFF
--- a/Backend/Remora.Discord.Caching/KeyHelpers.cs
+++ b/Backend/Remora.Discord.Caching/KeyHelpers.cs
@@ -60,7 +60,7 @@ public static class KeyHelpers
     /// <returns>The cache key.</returns>
     public static string CreateGuildInvitesCacheKey(in Snowflake guildID)
     {
-        return $"Guid:{guildID}:Invites";
+        return $"{CreateGuildCacheKey(guildID)}:Invites";
     }
 
     /// <summary>


### PR DESCRIPTION
Cache key returned by `CreateGuildInvitesCacheKey` started with `Guid:` instead of `Guild:`.
Fixed by switching to using `CreateGuildCacheKey` as other methods do too.