### PR TITLE
Use delegates instead of MethodInfo for dispatch

### DIFF
--- a/Backend/Remora.Discord.Gateway/Services/ResponderDispatchService.cs
+++ b/Backend/Remora.Discord.Gateway/Services/ResponderDispatchService.cs
@@ -312,9 +312,10 @@ public class ResponderDispatchService : IAsyncDisposable
     /// <param name="ct">The cancellation token for the dispatched event.</param>
     private Result<Task<IReadOnlyList<Result>>> UnwrapAndDispatchEvent(IPayload payload, CancellationToken ct = default)
     {
-        if (!_cachedInterfaceTypeArguments.TryGetValue(payload.GetType(), out var interfaceArgument))
+        var payloadType = payload.GetType();
+
+        if (!_cachedInterfaceTypeArguments.TryGetValue(payloadType, out var interfaceArgument))
         {
-            var payloadType = payload.GetType();
             if (!payloadType.IsGenericType)
             {
                 _log.LogWarning
@@ -343,7 +344,7 @@ public class ResponderDispatchService : IAsyncDisposable
             }
 
             interfaceArgument = payloadInterfaceType.GetGenericArguments()[0];
-            _cachedInterfaceTypeArguments.Add(payload.GetType(), interfaceArgument);
+            _cachedInterfaceTypeArguments.Add(payloadType, interfaceArgument);
         }
 
         if (!_cachedDispatchMethods.TryGetValue(interfaceArgument, out var boundDispatchMethod))


### PR DESCRIPTION
This PR adds an optimization for responder dispatch which replaces `MethodInfo` calls with delegates. In theory dispatch is now 17 times faster, but actual performance gains will probably be negligible. Below are the results of benchmarks of purely just MethodInfo versus delegate calls:

```fix
|          Method |       Mean |     Error |    StdDev | Allocated |
|---------------- |-----------:|----------:|----------:|----------:|
|      MethodInfo | 123.626 ns | 1.8388 ns | 1.5355 ns |      32 B |
| UnboundDelegate |   8.015 ns | 0.1286 ns | 0.1203 ns |         - |
|   BoundDelegate |   7.197 ns | 0.0738 ns | 0.0691 ns |         - |
```
