### PR TITLE
Fix early bailout not checking for slash command

### DIFF
--- a/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
@@ -347,7 +347,7 @@ public static class CommandTreeExtensions
                     ? string.Empty
                     : command.Shape.Description;
 
-                if (command.Shape.Description != Constants.DefaultDescription)
+                if (commandType is not ApplicationCommandType.ChatInput && command.Shape.Description != Constants.DefaultDescription)
                 {
                     return new UnsupportedFeatureError("Descriptions are not allowed on context menu commands.", node);
                 }


### PR DESCRIPTION
Early bailout doesn't check whether it is a description for a slash command, which is allowed to have one.

Introduced in 586a0aeef3cc28b9b6498ea6c59b40507c1603ec