### PR TITLE
Filter out null elements from attribute list

### DIFF
--- a/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/CommandTreeExtensions.cs
@@ -215,6 +215,7 @@ public static class CommandTreeExtensions
                         (
                             t => t.GetCustomAttribute<DiscordDefaultPermissionAttribute>()
                         )
+                        .Where(a => a is not null)
                         .ToList();
 
                     if (defaultPermissionAttributes.Count > 1)


### PR DESCRIPTION
`GetCustomAttribute` returns null if no matching attribute is found. This fixes the following `Count` check being incorrect.