### PR TITLE
Add ANSI formatting string builder

### DIFF
--- a/Remora.Discord.Extensions/Formatting/AnsiBackgroundColor.cs
+++ b/Remora.Discord.Extensions/Formatting/AnsiBackgroundColor.cs
@@ -1,0 +1,83 @@
+﻿//
+//  AnsiBackgroundColor.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+namespace Remora.Discord.Extensions.Formatting;
+
+/// <summary>
+/// Discord supported ANSI background colors.
+/// </summary>
+/// <remarks>Discord ANSI colors are based on Solarized palette.</remarks>
+public enum AnsiBackgroundColor
+{
+    /// <summary>
+    /// A base03 background color from Solarized palette.
+    /// </summary>
+    /// <remarks>Color Hex is #002b36.</remarks>
+    Base03 = 40,
+
+    /// <summary>
+    /// A orange background color.
+    /// </summary>
+    /// <remarks>Color Hex is #cb4b16.</remarks>
+    Orange = 41,
+
+    /// <summary>
+    /// A base01 background color from Solarized palette.
+    /// </summary>
+    /// <remarks>Color Hex is #586e75.</remarks>
+    Base01 = 42,
+
+    /// <summary>
+    /// A base00 background color from Solarized palette.
+    /// </summary>
+    /// <remarks>Color Hex is #657b83.</remarks>
+    Base00 = 43,
+
+    /// <summary>
+    /// A base0 background color from Solarized palette.
+    /// </summary>
+    /// <remarks>Color Hex is #839496.</remarks>
+    Base0 = 44,
+
+    /// <summary>
+    /// A violet background color.
+    /// </summary>
+    /// <remarks>Color Hex is #6c71c4.</remarks>
+    Violet = 45,
+
+    /// <summary>
+    /// A base1 background color from Solarized palette.
+    /// </summary>
+    /// <remarks>Color Hex is #93a1a1.</remarks>
+    Base1 = 46,
+
+    /// <summary>
+    /// A base3 background color from Solarized palette.
+    /// </summary>
+    /// <remarks>Color Hex is #fdf6e3.</remarks>
+    Base3 = 47,
+
+    /// <summary>
+    /// No background color.
+    /// </summary>
+    None = 49
+}

--- a/Remora.Discord.Extensions/Formatting/AnsiForegroundColor.cs
+++ b/Remora.Discord.Extensions/Formatting/AnsiForegroundColor.cs
@@ -1,0 +1,83 @@
+﻿//
+//  AnsiForegroundColor.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+namespace Remora.Discord.Extensions.Formatting;
+
+/// <summary>
+/// Discord supported ANSI foreground colors.
+/// </summary>
+/// <remarks>Discord ANSI colors are based on Solarized palette.</remarks>
+public enum AnsiForegroundColor
+{
+    /// <summary>
+    /// A black foreground color.
+    /// </summary>
+    /// <remarks>Color Hex is #4f545c, when a background is set then #073642 is used.</remarks>
+    Black = 30,
+
+    /// <summary>
+    /// A red foreground color.
+    /// </summary>
+    /// <remarks>Color Hex is #dc322f.</remarks>
+    Red = 31,
+
+    /// <summary>
+    /// A green foreground color.
+    /// </summary>
+    /// <remarks>Color Hex is #859900.</remarks>
+    Green = 32,
+
+    /// <summary>
+    /// A yellow foreground color.
+    /// </summary>
+    /// <remarks>Color Hex is #b58900.</remarks>
+    Yellow = 33,
+
+    /// <summary>
+    /// A blue foreground color.
+    /// </summary>
+    /// <remarks>Color Hex is #268bd2.</remarks>
+    Blue = 34,
+
+    /// <summary>
+    /// A magenta foreground color.
+    /// </summary>
+    /// <remarks>Color Hex is #d33682.</remarks>
+    Magenta = 35,
+
+    /// <summary>
+    /// A cyan foreground color.
+    /// </summary>
+    /// <remarks>Color Hex is #2aa198.</remarks>
+    Cyan = 36,
+
+    /// <summary>
+    /// A white foreground color.
+    /// </summary>
+    /// <remarks>Color Hex is #ffffff, when a background is set then #eee8d5 is used.</remarks>
+    White = 37,
+
+    /// <summary>
+    /// No foreground color.
+    /// </summary>
+    None = 39
+}

--- a/Remora.Discord.Extensions/Formatting/AnsiStringBuilder.cs
+++ b/Remora.Discord.Extensions/Formatting/AnsiStringBuilder.cs
@@ -1,0 +1,263 @@
+﻿//
+//  AnsiStringBuilder.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Text;
+
+namespace Remora.Discord.Extensions.Formatting;
+
+/// <summary>
+/// Provides a builder to build an ANSI formatted string.
+/// </summary>
+public class AnsiStringBuilder
+{
+    private readonly StringBuilder _builder;
+    private readonly StyleState _styleState;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AnsiStringBuilder"/> class.
+    /// </summary>
+    public AnsiStringBuilder()
+    {
+        _builder = new StringBuilder();
+        _styleState = new StyleState();
+    }
+
+    /// <summary>
+    /// Sets the current bold state of <see cref="AnsiStringBuilder"/> wether the upcoming the should be bold.
+    /// </summary>
+    /// <param name="bold">Wether to upcoming text should be bold.</param>
+    /// <returns>The current <see cref="AnsiStringBuilder"/> for chaining.</returns>
+    public AnsiStringBuilder Bold(bool bold = true)
+    {
+        _styleState.IsBold = bold;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the current underline state of <see cref="AnsiStringBuilder"/> wether the upcoming the should be underlined.
+    /// </summary>
+    /// <param name="underline">Wether to upcoming text should be underlined.</param>
+    /// <returns>The current <see cref="AnsiStringBuilder"/> for chaining.</returns>
+    public AnsiStringBuilder Underline(bool underline = true)
+    {
+        _styleState.IsUnderlined = underline;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the current foreround color of the <see cref="AnsiStringBuilder"/> to the specific foreground color.
+    /// </summary>
+    /// <param name="foregroundColor">The foreground color.</param>
+    /// <returns>The current <see cref="AnsiStringBuilder"/> for chaining.</returns>
+    public AnsiStringBuilder Foreground(AnsiForegroundColor foregroundColor = AnsiForegroundColor.None)
+    {
+        _styleState.ForegroundColor = foregroundColor;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the current background color of the <see cref="AnsiStringBuilder"/> to the specific background color.
+    /// </summary>
+    /// <param name="backgroundColor">The background color.</param>
+    /// <returns>The current <see cref="AnsiStringBuilder"/> for chaining.</returns>
+    public AnsiStringBuilder Background(AnsiBackgroundColor backgroundColor = AnsiBackgroundColor.None)
+    {
+        _styleState.BackgroundColor = backgroundColor;
+        return this;
+    }
+
+    /// <summary>
+    /// Resets all specified stylings.
+    /// </summary>
+    /// <returns>The current <see cref="AnsiStringBuilder"/> for chaining.</returns>
+    public AnsiStringBuilder Reset()
+    {
+        _styleState.Reset();
+        return this;
+    }
+
+    /// <summary>
+    /// Appends the <c>text</c> with the current styling.
+    /// </summary>
+    /// <param name="text">The text to append.</param>
+    /// <returns>The current <see cref="AnsiStringBuilder"/> for chaining.</returns>
+    public AnsiStringBuilder Append(string text)
+    {
+        _styleState.AppendToStringBuilder(_builder);
+        _builder.Append(text);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Appends the text with the current styling and adds a new line to the end.
+    /// </summary>
+    /// <param name="text">The text to append.</param>
+    /// <returns>The current <see cref="AnsiStringBuilder"/> for chaining.</returns>
+    public AnsiStringBuilder AppendLine(string? text = default)
+    {
+        if (text is not null)
+        {
+            Append(text);
+        }
+
+        _builder.Append('\n');
+        return this;
+    }
+
+    /// <summary>
+    /// Build the ansi formatted string.
+    /// </summary>
+    /// <returns>Returns a string containing the ansi formatting codes.</returns>
+    public string Build()
+    {
+        return _builder.ToString();
+    }
+
+    /// <summary>
+    /// Class for tracking the active styling state.
+    /// </summary>
+    private sealed class StyleState
+    {
+        private const char EscapeChar = '\u001b';
+
+        private bool _hasChanged = false;
+        private bool _isBold = false;
+        private bool _isUnderlined = false;
+        private AnsiForegroundColor _foregroundColor = AnsiForegroundColor.None;
+        private AnsiBackgroundColor _backgroundColor = AnsiBackgroundColor.None;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the text should be bold.
+        /// </summary>
+        public bool IsBold
+        {
+            get => _isBold;
+            set
+            {
+                if (_isBold != value)
+                {
+                    _isBold = value;
+                    _hasChanged = true;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the text should be underlined.
+        /// </summary>
+        public bool IsUnderlined
+        {
+            get => _isUnderlined;
+            set
+            {
+                if (_isUnderlined != value)
+                {
+                    _isUnderlined = value;
+                    _hasChanged = true;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the foreground color of the text.
+        /// </summary>
+        public AnsiForegroundColor ForegroundColor
+        {
+            get => _foregroundColor;
+            set
+            {
+                if (_foregroundColor != value)
+                {
+                    _foregroundColor = value;
+                    _hasChanged = true;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the background color of the text.
+        /// </summary>
+        public AnsiBackgroundColor BackgroundColor
+        {
+            get => _backgroundColor;
+            set
+            {
+                if (_backgroundColor != value)
+                {
+                    _backgroundColor = value;
+                    _hasChanged = true;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Resets the complete styling state to default values.
+        /// </summary>
+        public void Reset()
+        {
+            IsBold = false;
+            IsUnderlined = false;
+            ForegroundColor = AnsiForegroundColor.None;
+            BackgroundColor = AnsiBackgroundColor.None;
+        }
+
+        /// <summary>
+        /// Appends the ANSI formatting code when the styling has been changed.
+        /// </summary>
+        /// <param name="stringBuilder">The <see cref="StringBuilder"/> to append to.</param>
+        public void AppendToStringBuilder(StringBuilder stringBuilder)
+        {
+            // Do not append ANSI styling code when the style has not been changed
+            if (!_hasChanged)
+            {
+                return;
+            }
+
+            _hasChanged = false;
+
+            stringBuilder.Append($"{EscapeChar}[{AnsiStyle.Reset}");
+
+            if (_isBold)
+            {
+                stringBuilder.Append($";{AnsiStyle.Bold}");
+            }
+
+            if (_isUnderlined)
+            {
+                stringBuilder.Append($";{AnsiStyle.Underline}");
+            }
+
+            if (_backgroundColor is not AnsiBackgroundColor.None)
+            {
+                stringBuilder.Append($";{(int)_backgroundColor}");
+            }
+
+            if (_foregroundColor is not AnsiForegroundColor.None)
+            {
+                stringBuilder.Append($";{(int)_foregroundColor}");
+            }
+
+            stringBuilder.Append("m");
+        }
+    }
+}

--- a/Remora.Discord.Extensions/Formatting/AnsiStringBuilder.cs
+++ b/Remora.Discord.Extensions/Formatting/AnsiStringBuilder.cs
@@ -215,10 +215,10 @@ public class AnsiStringBuilder
         /// </summary>
         public void Reset()
         {
-            IsBold = false;
-            IsUnderlined = false;
-            ForegroundColor = AnsiForegroundColor.None;
-            BackgroundColor = AnsiBackgroundColor.None;
+            this.IsBold = false;
+            this.IsUnderlined = false;
+            this.ForegroundColor = AnsiForegroundColor.None;
+            this.BackgroundColor = AnsiBackgroundColor.None;
         }
 
         /// <summary>

--- a/Remora.Discord.Extensions/Formatting/AnsiStyle.cs
+++ b/Remora.Discord.Extensions/Formatting/AnsiStyle.cs
@@ -1,0 +1,44 @@
+﻿//
+//  AnsiStyle.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+namespace Remora.Discord.Extensions.Formatting;
+
+/// <summary>
+/// Discord supported ANSI styles.
+/// </summary>
+internal static class AnsiStyle
+{
+    /// <summary>
+    /// Resets all applied styling.
+    /// </summary>
+    public const int Reset = 0;
+
+    /// <summary>
+    /// Makes the text bold.
+    /// </summary>
+    public const int Bold = 1;
+
+    /// <summary>
+    /// Makes the text underlined.
+    /// </summary>
+    public const int Underline = 4;
+}

--- a/Tests/Remora.Discord.Extensions.Tests/AnsiStringBuilderTests.cs
+++ b/Tests/Remora.Discord.Extensions.Tests/AnsiStringBuilderTests.cs
@@ -1,0 +1,362 @@
+﻿//
+//  AnsiStringBuilderTests.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using Remora.Discord.Extensions.Formatting;
+using Xunit;
+
+namespace Remora.Discord.Extensions.Tests;
+
+/// <summary>
+/// Tests to ensure the <see cref="AnsiStringBuilder"/> build a correct ANSI formatted string.
+/// </summary>
+public class AnsiStringBuilderTests
+{
+    private const char AnsiEscapeChar = '\u001b';
+
+    /// <summary>
+    /// Tests to see if the <see cref="AnsiStringBuilder.Bold"/> method bolds the input text.
+    /// </summary>
+    /// <param name="data">The input text to format.</param>
+    [Theory]
+    [InlineData("Sample")]
+    [InlineData("Remora.Discord")]
+    public void BoldDefaultSuccess(string data)
+    {
+        var expected = $"{AnsiEscapeChar}[{AnsiStyle.Reset};{AnsiStyle.Bold}m{data}";
+        var actual = new AnsiStringBuilder().Bold().Append(data).Build();
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    /// Tests to see if the <see cref="AnsiStringBuilder.Bold"/> method bolds the first n characters.
+    /// </summary>
+    /// <param name="data">The input text to format.</param>
+    /// <param name="charCount">The n leading characeters that should be bold.</param>
+    [Theory]
+    [InlineData("Sample", 3)]
+    [InlineData("Remora.Discord", 7)]
+    public void BoldLeadingCharsSuccess(string data, int charCount)
+    {
+        var expected = $"{AnsiEscapeChar}[{AnsiStyle.Reset};{AnsiStyle.Bold}m{data.Remove(charCount)}" +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset}m{data.Substring(charCount)}";
+        var actual = new AnsiStringBuilder().Bold().Append(data.Remove(charCount))
+                                            .Bold(false).Append(data.Substring(charCount))
+                                            .Build();
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    /// Tests to see if the <see cref="AnsiStringBuilder.Underline"/> method underlines the input text.
+    /// </summary>
+    /// <param name="data">The input text to format.</param>
+    [Theory]
+    [InlineData("Sample")]
+    [InlineData("Remora.Discord")]
+    public void UnderlineDefaultSuccess(string data)
+    {
+        var expected = $"{AnsiEscapeChar}[{AnsiStyle.Reset};{AnsiStyle.Underline}m{data}";
+        var actual = new AnsiStringBuilder().Underline().Append(data).Build();
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    /// Tests to see if the <see cref="AnsiStringBuilder.Underline"/> method underlines the first n characters.
+    /// </summary>
+    /// <param name="data">The input text to format.</param>
+    /// <param name="charCount">The n leading characeters that should be underlined.</param>
+    [Theory]
+    [InlineData("Sample", 3)]
+    [InlineData("Remora.Discord", 7)]
+    public void UnderlineLeadingCharsSuccess(string data, int charCount)
+    {
+        var expected = $"{AnsiEscapeChar}[{AnsiStyle.Reset};{AnsiStyle.Underline}m{data.Remove(charCount)}" +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset}m{data.Substring(charCount)}";
+        var actual = new AnsiStringBuilder().Underline().Append(data.Remove(charCount))
+                                            .Underline(false).Append(data.Substring(charCount))
+                                            .Build();
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    /// Tests to see if the <see cref="AnsiStringBuilder.Foreground"/> method sets the foreground color for the input text.
+    /// </summary>
+    /// <param name="data">The input text to format.</param>
+    [Theory]
+    [InlineData("Sample")]
+    [InlineData("Remora.Discord")]
+    public void ForegroundDefaultSuccess(string data)
+    {
+        AnsiForegroundColor[] foregroundColors = Enum.GetValues<AnsiForegroundColor>();
+
+        foreach (var foregroundColor in foregroundColors)
+        {
+            string expected;
+
+            // Foreground color None has some special handling
+            if (foregroundColor == AnsiForegroundColor.None)
+            {
+                expected = $"{data}";
+            }
+            else
+            {
+                expected = $"{AnsiEscapeChar}[{AnsiStyle.Reset};{(int)foregroundColor}m{data}";
+            }
+
+            var actual = new AnsiStringBuilder().Foreground(foregroundColor).Append(data).Build();
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    /// <summary>
+    /// Tests to see if the <see cref="AnsiStringBuilder.Foreground"/> method sets the foreground color for the first n characters.
+    /// </summary>
+    /// <param name="data">The input text to format.</param>
+    /// <param name="charCount">The n leading characeters that should have a foreground color.</param>
+    [Theory]
+    [InlineData("Sample", 3)]
+    [InlineData("Remora.Discord", 7)]
+    public void ForegroundLeadingCharsSuccess(string data, int charCount)
+    {
+        AnsiForegroundColor[] foregroundColors = Enum.GetValues<AnsiForegroundColor>();
+
+        foreach (var foregroundColor in foregroundColors)
+        {
+            string expected;
+
+            // Foreground color None has some special handling
+            if (foregroundColor == AnsiForegroundColor.None)
+            {
+                expected = $"{data}";
+            }
+            else
+            {
+                expected = $"{AnsiEscapeChar}[{AnsiStyle.Reset};{(int)foregroundColor}m{data.Remove(charCount)}" +
+                           $"{AnsiEscapeChar}[{AnsiStyle.Reset}m{data.Substring(charCount)}";
+            }
+
+            var actual = new AnsiStringBuilder().Foreground(foregroundColor).Append(data.Remove(charCount))
+                                                .Foreground().Append(data.Substring(charCount))
+                                                .Build();
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    /// <summary>
+    /// Tests to see if the <see cref="AnsiStringBuilder.Background"/> method sets the background color for the input text.
+    /// </summary>
+    /// <param name="data">The input text to format.</param>
+    [Theory]
+    [InlineData("Sample")]
+    [InlineData("Remora.Discord")]
+    public void BackgroundDefaultSuccess(string data)
+    {
+        AnsiBackgroundColor[] backgroundColors = Enum.GetValues<AnsiBackgroundColor>();
+
+        foreach (var backgroundColor in backgroundColors)
+        {
+            string expected;
+
+            // Background color None has some special handling
+            if (backgroundColor == AnsiBackgroundColor.None)
+            {
+                expected = $"{data}";
+            }
+            else
+            {
+                expected = $"{AnsiEscapeChar}[{AnsiStyle.Reset};{(int)backgroundColor}m{data}";
+            }
+
+            var actual = new AnsiStringBuilder().Background(backgroundColor).Append(data).Build();
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    /// <summary>
+    /// Tests to see if the <see cref="AnsiStringBuilder.Background"/> method sets the background color for the first n characters.
+    /// </summary>
+    /// <param name="data">The input text to format.</param>
+    /// <param name="charCount">The n leading characeters that should have a background color.</param>
+    [Theory]
+    [InlineData("Sample", 3)]
+    [InlineData("Remora.Discord", 7)]
+    public void BackgroundLeadingCharsSuccess(string data, int charCount)
+    {
+        AnsiBackgroundColor[] backgroundColors = Enum.GetValues<AnsiBackgroundColor>();
+
+        foreach (var backgroundColor in backgroundColors)
+        {
+            string expected;
+
+            // Foreground color None has some special handling
+            if (backgroundColor == AnsiBackgroundColor.None)
+            {
+                expected = $"{data}";
+            }
+            else
+            {
+                expected = $"{AnsiEscapeChar}[{AnsiStyle.Reset};{(int)backgroundColor}m{data.Remove(charCount)}" +
+                           $"{AnsiEscapeChar}[{AnsiStyle.Reset}m{data.Substring(charCount)}";
+            }
+
+            var actual = new AnsiStringBuilder().Background(backgroundColor).Append(data.Remove(charCount))
+                                                .Background().Append(data.Substring(charCount))
+                                                .Build();
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    /// <summary>
+    /// Tests to see if mixing <see cref="AnsiStringBuilder.Bold"/> and <see cref="AnsiStringBuilder.Underline"/> method format as expected.
+    /// </summary>
+    [Fact]
+    public void MixBoldAndUnderlineSuccess()
+    {
+        var expected = "Does " +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset};{AnsiStyle.Bold}mbold{AnsiEscapeChar}[{AnsiStyle.Reset}m" +
+                       " and " +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset};{AnsiStyle.Underline}munderline{AnsiEscapeChar}[{AnsiStyle.Reset}m" +
+                       " " +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset};{AnsiStyle.Bold};{AnsiStyle.Underline}mmix{AnsiEscapeChar}[{AnsiStyle.Reset}m" +
+                       "?";
+
+        var actual = new AnsiStringBuilder().Append("Does ")
+                                            .Bold().Append("bold").Bold(false)
+                                            .Append(" and ")
+                                            .Underline().Append("underline").Underline(false)
+                                            .Append(" ")
+                                            .Bold().Underline().Append("mix").Bold(false).Underline(false)
+                                            .Append("?")
+                                            .Build();
+
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    /// Tests to see if mixing <see cref="AnsiStringBuilder.Foreground"/> and <see cref="AnsiStringBuilder.Background"/> method format as expected.
+    /// </summary>
+    /// <param name="foregroundColor">The foreground color to use.</param>
+    /// <param name="backgroundColor">The background color to use.</param>
+    [Theory]
+    [InlineData(AnsiForegroundColor.Red, AnsiBackgroundColor.Violet)]
+    [InlineData(AnsiForegroundColor.Magenta, AnsiBackgroundColor.Base0)]
+    [InlineData(AnsiForegroundColor.Cyan, AnsiBackgroundColor.Orange)]
+    public void MixForegroundAndBackgroundSuccess(AnsiForegroundColor foregroundColor, AnsiBackgroundColor backgroundColor)
+    {
+        var expected = "Does " +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset};{(int)foregroundColor}mforeground{AnsiEscapeChar}[{AnsiStyle.Reset}m" +
+                       " and " +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset};{(int)backgroundColor}mbackground{AnsiEscapeChar}[{AnsiStyle.Reset}m" +
+                       " " +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset};{(int)backgroundColor};{(int)foregroundColor}mmix{AnsiEscapeChar}[{AnsiStyle.Reset}m" +
+                       "?";
+
+        var actual = new AnsiStringBuilder().Append("Does ")
+                                            .Foreground(foregroundColor).Append("foreground").Foreground()
+                                            .Append(" and ")
+                                            .Background(backgroundColor).Append("background").Background()
+                                            .Append(" ")
+                                            .Foreground(foregroundColor).Background(backgroundColor).Append("mix").Foreground().Background()
+                                            .Append("?")
+                                            .Build();
+
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    /// Tests to see if mixing <see cref="AnsiStringBuilder.Bold"/> and <see cref="AnsiStringBuilder.Underline"/> and
+    /// <see cref="AnsiStringBuilder.Foreground"/> and <see cref="AnsiStringBuilder.Background"/> method format as expected.
+    /// </summary>
+    /// <param name="foregroundColor">The foreground color to use.</param>
+    /// <param name="backgroundColor">The background color to use.</param>
+    [Theory]
+    [InlineData(AnsiForegroundColor.Red, AnsiBackgroundColor.Violet)]
+    [InlineData(AnsiForegroundColor.Magenta, AnsiBackgroundColor.Base0)]
+    [InlineData(AnsiForegroundColor.Cyan, AnsiBackgroundColor.Orange)]
+    public void MixAllSuccess(AnsiForegroundColor foregroundColor, AnsiBackgroundColor backgroundColor)
+    {
+        var expected = "Does " +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset};{AnsiStyle.Bold}mbold{AnsiEscapeChar}[{AnsiStyle.Reset}m" +
+                       " and " +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset};{AnsiStyle.Underline}munderline{AnsiEscapeChar}[{AnsiStyle.Reset}m" +
+                       " and " +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset};{(int)foregroundColor}mforeground{AnsiEscapeChar}[{AnsiStyle.Reset}m" +
+                       " and " +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset};{(int)backgroundColor}mbackground{AnsiEscapeChar}[{AnsiStyle.Reset}m" +
+                       " " +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset};{AnsiStyle.Bold};{AnsiStyle.Underline};{(int)backgroundColor};{(int)foregroundColor}m" +
+                           "mix" +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset}m" +
+                       "?";
+
+        var actual = new AnsiStringBuilder().Append("Does ")
+                                            .Bold().Append("bold").Bold(false)
+                                            .Append(" and ")
+                                            .Underline().Append("underline").Underline(false)
+                                            .Append(" and ")
+                                            .Foreground(foregroundColor).Append("foreground").Foreground()
+                                            .Append(" and ")
+                                            .Background(backgroundColor).Append("background").Background()
+                                            .Append(" ")
+                                            .Bold().Underline().Foreground(foregroundColor).Background(backgroundColor)
+                                                .Append("mix")
+                                            .Bold(false).Underline(false).Foreground().Background()
+                                            .Append("?")
+                                            .Build();
+
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    /// Tests to see if the <see cref="AnsiStringBuilder.Reset"/> method resets the styling.
+    /// </summary>
+    [Fact]
+    public void ResetSuccess()
+    {
+        var expected = $"{AnsiEscapeChar}[{AnsiStyle.Reset};{AnsiStyle.Bold}mBold{AnsiEscapeChar}[{AnsiStyle.Reset}m" +
+                       " and " +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset};{AnsiStyle.Underline}munderlined{AnsiEscapeChar}[{AnsiStyle.Reset}m" +
+                       " " +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset};{AnsiStyle.Bold};{AnsiStyle.Underline}mcombined{AnsiEscapeChar}[{AnsiStyle.Reset}m" +
+                       "!\n" +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset};{(int)AnsiForegroundColor.Red}mShould " +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset};{(int)AnsiBackgroundColor.Base0};{(int)AnsiForegroundColor.Red}mreset " +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset};{AnsiStyle.Underline};{(int)AnsiBackgroundColor.Base0};{(int)AnsiForegroundColor.Red}malso " +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset};{AnsiStyle.Bold};{AnsiStyle.Underline};{(int)AnsiBackgroundColor.Base0};{(int)AnsiForegroundColor.Red}mcolors" +
+                       $"{AnsiEscapeChar}[{AnsiStyle.Reset}m!";
+
+        var actual = new AnsiStringBuilder().Bold().Append("Bold").Reset()
+                                            .Append(" and ")
+                                            .Underline().Append("underlined").Reset()
+                                            .Append(" ")
+                                            .Bold().Underline().Append("combined").Reset()
+                                            .AppendLine("!")
+                                            .Foreground(AnsiForegroundColor.Red).Append("Should ")
+                                            .Background(AnsiBackgroundColor.Base0).Append("reset ")
+                                            .Underline().Append("also ")
+                                            .Bold().Append("colors").Reset()
+                                            .Append("!")
+                                            .Build();
+
+        Assert.Equal(expected, actual);
+    }
+}


### PR DESCRIPTION
Provides a class to build an ANSI formatted string that is supported by Discords ANSI code blocks.

#### Notes
- Only works in ANSI code blocks
- Supported only on desktop clients

### Example
![Sample - Dark](https://cdn.discordapp.com/attachments/969719577334415420/969720848317562910/unknown.png)

### Implementation
The implementation of the build builds the string as in this gist:  [here](https://gist.github.com/MazeXP/617fcf7c8d632cfbf3a7376753df6307#file-6-preview-md)
The class is used like this: [here](https://gist.github.com/MazeXP/617fcf7c8d632cfbf3a7376753df6307#file-5-sample-cs)

### Discussion
I am open to have a discussion about this implementation and also open for suggestions.  