### PR TITLE
Add missing permission parameters for application methods

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestApplicationAPI.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestApplicationAPI.cs
@@ -192,7 +192,6 @@ public interface IDiscordRestApplicationAPI
     /// <param name="nameLocalizations">The localized names of the command.</param>
     /// <param name="descriptionLocalizations">The localized descriptions of the command.</param>
     /// <param name="defaultMemberPermissions">The permissions required to execute the command.</param>
-    /// <param name="dmPermission">Whether this command is executable in DMs.</param>
     /// <param name="ct">The cancellation token for this operation.</param>
     /// <returns>A creation result which may or may not have succeeded.</returns>
     Task<Result<IApplicationCommand>> CreateGuildApplicationCommandAsync
@@ -206,7 +205,6 @@ public interface IDiscordRestApplicationAPI
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
         Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
-        Optional<bool?> dmPermission = default,
         CancellationToken ct = default
     );
 
@@ -254,9 +252,9 @@ public interface IDiscordRestApplicationAPI
     /// <param name="nameLocalizations">The localized names of the command.</param>
     /// <param name="descriptionLocalizations">The localized descriptions of the command.</param>
     /// <param name="defaultMemberPermissions">The permissions required to execute the command.</param>
-    /// <param name="dmPermission">Whether this command is executable in DMs.</param>
     /// <param name="ct">The cancellation token for this operation.</param>
     /// <returns>A creation result which may or may not have succeeded.</returns>
+    /// <remarks>This method requires a bearer token authorized with the applications.commands.permissions.update scope.</remarks>
     Task<Result<IApplicationCommand>> EditGuildApplicationCommandAsync
     (
         Snowflake applicationID,
@@ -268,7 +266,6 @@ public interface IDiscordRestApplicationAPI
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
         Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
-        Optional<bool?> dmPermission = default,
         CancellationToken ct = default
     );
 
@@ -327,9 +324,7 @@ public interface IDiscordRestApplicationAPI
     /// <param name="permissions">The permissions to overwrite the existing ones with.</param>
     /// <param name="ct">The cancellation token for this operation.</param>
     /// <returns>An edit result which may or may not have succeeded.</returns>
-    /// <remarks>
-    /// Using this method requires a bearer token authorized with the applications.commands.permissions.update OAuth2 scope.
-    /// </remarks>
+    /// <remarks>This method requires a bearer token authorized with the applications.commands.permissions.update scope.</remarks>
     Task<Result<IGuildApplicationCommandPermissions>> EditApplicationCommandPermissionsAsync
     (
         Snowflake applicationID,

--- a/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestApplicationAPI.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestApplicationAPI.cs
@@ -21,6 +21,7 @@
 //
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -34,6 +35,7 @@ namespace Remora.Discord.API.Abstractions.Rest;
 /// Represents the Discord application API.
 /// </summary>
 [PublicAPI]
+[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1305:Field names should not use Hungarian notation", Justification = "DM is an abbreviation.")]
 public interface IDiscordRestApplicationAPI
 {
     /// <summary>
@@ -64,10 +66,11 @@ public interface IDiscordRestApplicationAPI
     /// <param name="name">The name of the command. 3-32 characters.</param>
     /// <param name="description">The description of the command. 1-100 characters.</param>
     /// <param name="options">The parameters for the command.</param>
-    /// <param name="defaultPermission">Whether the command is enabled by default in a guild.</param>
     /// <param name="type">The type of the application command.</param>
     /// <param name="nameLocalizations">The localized names of the command.</param>
     /// <param name="descriptionLocalizations">The localized descriptions of the command.</param>
+    /// <param name="defaultMemberPermissions">The permissions required to execute the command.</param>
+    /// <param name="dmPermission">Whether this command is executable in DMs.</param>
     /// <param name="ct">The cancellation token for this operation.</param>
     /// <returns>A creation result which may or may not have succeeded.</returns>
     Task<Result<IApplicationCommand>> CreateGlobalApplicationCommandAsync
@@ -76,10 +79,11 @@ public interface IDiscordRestApplicationAPI
         string name,
         string description,
         Optional<IReadOnlyList<IApplicationCommandOption>> options = default,
-        Optional<bool> defaultPermission = default,
         Optional<ApplicationCommandType> type = default,
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
+        Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
+        Optional<bool?> dmPermission = default,
         CancellationToken ct = default
     );
 
@@ -119,9 +123,10 @@ public interface IDiscordRestApplicationAPI
     /// <param name="name">The name of the command. 3-32 characters.</param>
     /// <param name="description">The description of the command. 1-100 characters.</param>
     /// <param name="options">The parameters for the command.</param>
-    /// <param name="defaultPermission">Whether the command is enabled by default in a guild.</param>
     /// <param name="nameLocalizations">The localized names of the command.</param>
     /// <param name="descriptionLocalizations">The localized descriptions of the command.</param>
+    /// <param name="defaultMemberPermissions">The permissions required to execute the command.</param>
+    /// <param name="dmPermission">Whether this command is executable in DMs.</param>
     /// <param name="ct">The cancellation token for this operation.</param>
     /// <returns>A creation result which may or may not have succeeded.</returns>
     Task<Result<IApplicationCommand>> EditGlobalApplicationCommandAsync
@@ -131,9 +136,10 @@ public interface IDiscordRestApplicationAPI
         Optional<string> name = default,
         Optional<string> description = default,
         Optional<IReadOnlyList<IApplicationCommandOption>?> options = default,
-        Optional<bool> defaultPermission = default,
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
+        Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
+        Optional<bool?> dmPermission = default,
         CancellationToken ct = default
     );
 
@@ -182,10 +188,11 @@ public interface IDiscordRestApplicationAPI
     /// <param name="name">The name of the command. 3-32 characters.</param>
     /// <param name="description">The description of the command. 1-100 characters.</param>
     /// <param name="options">The parameters for the command.</param>
-    /// <param name="defaultPermission">Whether the command is enabled by default in a guild.</param>
     /// <param name="type">The type of the application command.</param>
     /// <param name="nameLocalizations">The localized names of the command.</param>
     /// <param name="descriptionLocalizations">The localized descriptions of the command.</param>
+    /// <param name="defaultMemberPermissions">The permissions required to execute the command.</param>
+    /// <param name="dmPermission">Whether this command is executable in DMs.</param>
     /// <param name="ct">The cancellation token for this operation.</param>
     /// <returns>A creation result which may or may not have succeeded.</returns>
     Task<Result<IApplicationCommand>> CreateGuildApplicationCommandAsync
@@ -195,10 +202,11 @@ public interface IDiscordRestApplicationAPI
         string name,
         string description,
         Optional<IReadOnlyList<IApplicationCommandOption>> options = default,
-        Optional<bool> defaultPermission = default,
         Optional<ApplicationCommandType> type = default,
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
+        Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
+        Optional<bool?> dmPermission = default,
         CancellationToken ct = default
     );
 
@@ -243,9 +251,10 @@ public interface IDiscordRestApplicationAPI
     /// <param name="name">The name of the command. 3-32 characters.</param>
     /// <param name="description">The description of the command. 1-100 characters.</param>
     /// <param name="options">The parameters for the command.</param>
-    /// <param name="defaultPermission">Whether the command is enabled by default in a guild.</param>
     /// <param name="nameLocalizations">The localized names of the command.</param>
     /// <param name="descriptionLocalizations">The localized descriptions of the command.</param>
+    /// <param name="defaultMemberPermissions">The permissions required to execute the command.</param>
+    /// <param name="dmPermission">Whether this command is executable in DMs.</param>
     /// <param name="ct">The cancellation token for this operation.</param>
     /// <returns>A creation result which may or may not have succeeded.</returns>
     Task<Result<IApplicationCommand>> EditGuildApplicationCommandAsync
@@ -256,9 +265,10 @@ public interface IDiscordRestApplicationAPI
         Optional<string> name = default,
         Optional<string> description = default,
         Optional<IReadOnlyList<IApplicationCommandOption>?> options = default,
-        Optional<bool> defaultPermission = default,
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
+        Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
+        Optional<bool?> dmPermission = default,
         CancellationToken ct = default
     );
 

--- a/Backend/Remora.Discord.Rest/API/Applications/DiscordRestApplicationAPI.cs
+++ b/Backend/Remora.Discord.Rest/API/Applications/DiscordRestApplicationAPI.cs
@@ -364,7 +364,6 @@ public class DiscordRestApplicationAPI : AbstractDiscordRestAPI, IDiscordRestApp
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
         Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
-        Optional<bool?> dmPermission = default,
         CancellationToken ct = default
     )
     {
@@ -407,7 +406,6 @@ public class DiscordRestApplicationAPI : AbstractDiscordRestAPI, IDiscordRestApp
                         json.Write("name_localizations", nameLocalizations, this.JsonOptions);
                         json.Write("description_localizations", descriptionLocalizations, this.JsonOptions);
                         json.Write("default_member_permissions", defaultMemberPermissions, this.JsonOptions);
-                        json.Write("dm_permission", dmPermission, this.JsonOptions);
                     }
                 )
                 .WithRateLimitContext(this.RateLimitCache),
@@ -444,7 +442,6 @@ public class DiscordRestApplicationAPI : AbstractDiscordRestAPI, IDiscordRestApp
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
         Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
-        Optional<bool?> dmPermission = default,
         CancellationToken ct = default
     )
     {
@@ -479,7 +476,6 @@ public class DiscordRestApplicationAPI : AbstractDiscordRestAPI, IDiscordRestApp
                         json.Write("name_localizations", nameLocalizations, this.JsonOptions);
                         json.Write("description_localizations", descriptionLocalizations, this.JsonOptions);
                         json.Write("default_member_permissions", defaultMemberPermissions, this.JsonOptions);
-                        json.Write("dm_permission", dmPermission, this.JsonOptions);
                     }
                 )
                 .WithRateLimitContext(this.RateLimitCache),

--- a/Backend/Remora.Discord.Rest/API/Applications/DiscordRestApplicationAPI.cs
+++ b/Backend/Remora.Discord.Rest/API/Applications/DiscordRestApplicationAPI.cs
@@ -21,6 +21,7 @@
 //
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Json;
 using System.Threading;
@@ -39,6 +40,7 @@ namespace Remora.Discord.Rest.API;
 
 /// <inheritdoc cref="Remora.Discord.API.Abstractions.Rest.IDiscordRestApplicationAPI" />
 [PublicAPI]
+[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1305:Field names should not use Hungarian notation", Justification = "DM is an abbreviation.")]
 public class DiscordRestApplicationAPI : AbstractDiscordRestAPI, IDiscordRestApplicationAPI
 {
     /// <summary>
@@ -89,10 +91,11 @@ public class DiscordRestApplicationAPI : AbstractDiscordRestAPI, IDiscordRestApp
         string name,
         string description,
         Optional<IReadOnlyList<IApplicationCommandOption>> options = default,
-        Optional<bool> defaultPermission = default,
         Optional<ApplicationCommandType> type = default,
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
+        Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
+        Optional<bool?> dmPermission = default,
         CancellationToken ct = default
     )
     {
@@ -132,9 +135,10 @@ public class DiscordRestApplicationAPI : AbstractDiscordRestAPI, IDiscordRestApp
                         json.Write("type", type, this.JsonOptions);
                         json.WriteString("description", description);
                         json.Write("options", options, this.JsonOptions);
-                        json.Write("default_permission", defaultPermission, this.JsonOptions);
                         json.Write("name_localizations", nameLocalizations, this.JsonOptions);
                         json.Write("description_localizations", descriptionLocalizations, this.JsonOptions);
+                        json.Write("default_member_permissions", defaultMemberPermissions, this.JsonOptions);
+                        json.Write("dm_permission", dmPermission, this.JsonOptions);
                     }
                 )
                 .WithRateLimitContext(this.RateLimitCache),
@@ -209,9 +213,10 @@ public class DiscordRestApplicationAPI : AbstractDiscordRestAPI, IDiscordRestApp
         Optional<string> name = default,
         Optional<string> description = default,
         Optional<IReadOnlyList<IApplicationCommandOption>?> options = default,
-        Optional<bool> defaultPermission = default,
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
+        Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
+        Optional<bool?> dmPermission = default,
         CancellationToken ct = default
     )
     {
@@ -244,9 +249,10 @@ public class DiscordRestApplicationAPI : AbstractDiscordRestAPI, IDiscordRestApp
                         json.Write("name", name, this.JsonOptions);
                         json.Write("description", description, this.JsonOptions);
                         json.Write("options", options, this.JsonOptions);
-                        json.Write("default_permission", defaultPermission, this.JsonOptions);
                         json.Write("name_localizations", nameLocalizations, this.JsonOptions);
                         json.Write("description_localizations", descriptionLocalizations, this.JsonOptions);
+                        json.Write("default_member_permissions", defaultMemberPermissions, this.JsonOptions);
+                        json.Write("dm_permission", dmPermission, this.JsonOptions);
                     }
                 )
                 .WithRateLimitContext(this.RateLimitCache),
@@ -354,10 +360,11 @@ public class DiscordRestApplicationAPI : AbstractDiscordRestAPI, IDiscordRestApp
         string name,
         string description,
         Optional<IReadOnlyList<IApplicationCommandOption>> options = default,
-        Optional<bool> defaultPermission = default,
         Optional<ApplicationCommandType> type = default,
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
+        Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
+        Optional<bool?> dmPermission = default,
         CancellationToken ct = default
     )
     {
@@ -397,9 +404,10 @@ public class DiscordRestApplicationAPI : AbstractDiscordRestAPI, IDiscordRestApp
                         json.Write("type", type, this.JsonOptions);
                         json.WriteString("description", description);
                         json.Write("options", options, this.JsonOptions);
-                        json.Write("default_permission", defaultPermission, this.JsonOptions);
                         json.Write("name_localizations", nameLocalizations, this.JsonOptions);
                         json.Write("description_localizations", descriptionLocalizations, this.JsonOptions);
+                        json.Write("default_member_permissions", defaultMemberPermissions, this.JsonOptions);
+                        json.Write("dm_permission", dmPermission, this.JsonOptions);
                     }
                 )
                 .WithRateLimitContext(this.RateLimitCache),
@@ -433,9 +441,10 @@ public class DiscordRestApplicationAPI : AbstractDiscordRestAPI, IDiscordRestApp
         Optional<string> name = default,
         Optional<string> description = default,
         Optional<IReadOnlyList<IApplicationCommandOption>?> options = default,
-        Optional<bool> defaultPermission = default,
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
+        Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
+        Optional<bool?> dmPermission = default,
         CancellationToken ct = default
     )
     {
@@ -467,9 +476,10 @@ public class DiscordRestApplicationAPI : AbstractDiscordRestAPI, IDiscordRestApp
                         json.Write("name", name, this.JsonOptions);
                         json.Write("description", description, this.JsonOptions);
                         json.Write("options", options, this.JsonOptions);
-                        json.Write("default_permission", defaultPermission, this.JsonOptions);
                         json.Write("name_localizations", nameLocalizations, this.JsonOptions);
                         json.Write("description_localizations", descriptionLocalizations, this.JsonOptions);
+                        json.Write("default_member_permissions", defaultMemberPermissions, this.JsonOptions);
+                        json.Write("dm_permission", dmPermission, this.JsonOptions);
                     }
                 )
                 .WithRateLimitContext(this.RateLimitCache),

--- a/Tests/Remora.Discord.Rest.Tests/API/Applications/DiscordRestApplicationAPITests.cs
+++ b/Tests/Remora.Discord.Rest.Tests/API/Applications/DiscordRestApplicationAPITests.cs
@@ -114,6 +114,7 @@ public class DiscordRestApplicationAPITests
                                 .WithProperty("description", p => p.Is(description))
                                 .WithProperty("options", p => p.IsArray())
                                 .WithProperty("default_member_permissions", p => p.Is(permissions.Value.ToString()))
+                                .WithProperty("dm_permission", p => p.Is(false))
                         )
                     )
                     .Respond("application/json", SampleRepository.Samples[typeof(IApplicationCommand)])
@@ -126,6 +127,7 @@ public class DiscordRestApplicationAPITests
                 description,
                 options,
                 defaultMemberPermissions: permissions,
+                dmPermission: false,
                 type: type
             );
 

--- a/Tests/Remora.Discord.Rest.Tests/API/Applications/DiscordRestApplicationAPITests.cs
+++ b/Tests/Remora.Discord.Rest.Tests/API/Applications/DiscordRestApplicationAPITests.cs
@@ -113,7 +113,7 @@ public class DiscordRestApplicationAPITests
                                 .WithProperty("type", p => p.Is((int)type))
                                 .WithProperty("description", p => p.Is(description))
                                 .WithProperty("options", p => p.IsArray())
-                                .WithProperty("defualt_member_permissions", p => p.Is(permissions.Value.ToString()))
+                                .WithProperty("default_member_permissions", p => p.Is(permissions.Value.ToString()))
                         )
                     )
                     .Respond("application/json", SampleRepository.Samples[typeof(IApplicationCommand)])

--- a/Tests/Remora.Discord.Rest.Tests/API/Applications/DiscordRestApplicationAPITests.cs
+++ b/Tests/Remora.Discord.Rest.Tests/API/Applications/DiscordRestApplicationAPITests.cs
@@ -98,6 +98,7 @@ public class DiscordRestApplicationAPITests
             var name = "aaa";
             var description = "wwww";
             var options = new List<ApplicationCommandOption>();
+            var permissions = new DiscordPermissionSet(DiscordPermission.Administrator);
 
             var api = CreateAPI
             (
@@ -112,6 +113,7 @@ public class DiscordRestApplicationAPITests
                                 .WithProperty("type", p => p.Is((int)type))
                                 .WithProperty("description", p => p.Is(description))
                                 .WithProperty("options", p => p.IsArray())
+                                .WithProperty("defualt_member_permissions", p => p.Is(permissions.Value.ToString()))
                         )
                     )
                     .Respond("application/json", SampleRepository.Samples[typeof(IApplicationCommand)])
@@ -123,6 +125,7 @@ public class DiscordRestApplicationAPITests
                 name,
                 description,
                 options,
+                defaultMemberPermissions: permissions,
                 type: type
             );
 
@@ -959,6 +962,7 @@ public class DiscordRestApplicationAPITests
             var name = "aaa";
             var description = "wwww";
             var options = new List<ApplicationCommandOption>();
+            var permissions = new DiscordPermissionSet(DiscordPermission.Administrator);
 
             var api = CreateAPI
             (
@@ -977,6 +981,7 @@ public class DiscordRestApplicationAPITests
                                 .WithProperty("type", p => p.Is((int)type))
                                 .WithProperty("description", p => p.Is(description))
                                 .WithProperty("options", p => p.IsArray())
+                                .WithProperty("default_member_permissions", p => p.Is(permissions.Value.ToString()))
                         )
                     )
                     .Respond("application/json", SampleRepository.Samples[typeof(IApplicationCommand)])
@@ -989,6 +994,7 @@ public class DiscordRestApplicationAPITests
                 name,
                 description,
                 options,
+                defaultMemberPermissions: permissions,
                 type: type
             );
 

--- a/stylecop.json
+++ b/stylecop.json
@@ -27,7 +27,8 @@
             "allowedHungarianPrefixes" : [
                 "gl",
                 "f",
-                "db"
+                "db",
+                "dm"
             ]
         },
         "maintainabilityRules" : {


### PR DESCRIPTION
This PR adds missing parameters (DefaultMemberPermissions, DMPermission) to the appropriate methods on IDiscordRestApplicationAPI and it's implementation