### PR TITLE
Change default of `DiscordDefaultDMPermissionAttribute` to true

### DIFF
--- a/Remora.Discord.Commands/Attributes/DiscordDefaultDMPermissionAttribute.cs
+++ b/Remora.Discord.Commands/Attributes/DiscordDefaultDMPermissionAttribute.cs
@@ -39,7 +39,7 @@ public class DiscordDefaultDMPermissionAttribute : Attribute
     /// Initializes a new instance of the <see cref="DiscordDefaultDMPermissionAttribute"/> class.
     /// </summary>
     /// <param name="isExecutableInDMs">Whether this command group is executable in a DM.</param>
-    public DiscordDefaultDMPermissionAttribute(bool isExecutableInDMs = false)
+    public DiscordDefaultDMPermissionAttribute(bool isExecutableInDMs = true)
     {
         this.IsExecutableInDMs = isExecutableInDMs;
     }


### PR DESCRIPTION

The default when `dm_permission` is unset is to have the command be visible in DMs.
The current default of `false` also makes the attribute unintuitive to use, as setting `[DiscordDefaultDMPermission]` is same as `[DiscordDefaultDMPermission(false)]` and would disable the command.

See: https://discord.com/developers/docs/interactions/application-commands#application-command-object
> Indicates whether the command is available in DMs with the app, only for globally-scoped commands. By default, commands are visible.