### PR TITLE
Implement interaction response tracking

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/ApplicationCommands/IApplicationCommand.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/Interactions/ApplicationCommands/IApplicationCommand.cs
@@ -20,7 +20,6 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Remora.Rest.Core;

--- a/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestApplicationAPI.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestApplicationAPI.cs
@@ -21,7 +21,6 @@
 //
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;

--- a/Backend/Remora.Discord.API/API/Objects/Interactions/ApplicationCommands/BulkApplicationCommandData.cs
+++ b/Backend/Remora.Discord.API/API/Objects/Interactions/ApplicationCommands/BulkApplicationCommandData.cs
@@ -20,7 +20,6 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;

--- a/Backend/Remora.Discord.API/Remora.Discord.API.csproj
+++ b/Backend/Remora.Discord.API/Remora.Discord.API.csproj
@@ -18,7 +18,7 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
         <PackageReference Include="System.Text.Json" Version="6.0.4" />
-        <PackageReference Include="Remora.Rest" Version="1.2.4" />
+        <PackageReference Include="Remora.Rest" Version="2.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestChannelAPI.Delegations.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestChannelAPI.Delegations.cs
@@ -20,11 +20,13 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Remora.Discord.API.Abstractions.Objects;
+using Remora.Rest;
 using Remora.Rest.Core;
 using Remora.Results;
 
@@ -324,5 +326,28 @@ public partial class CachingDiscordRestChannelAPI
     public Task<Result> LeaveThreadAsync(Snowflake channelID, CancellationToken ct = default)
     {
         return _actual.LeaveThreadAsync(channelID, ct);
+    }
+
+    /// <inheritdoc/>
+    public RestRequestCustomization WithCustomization(Action<RestRequestBuilder> requestCustomizer)
+    {
+        if (_actual is not IRestCustomizable customizable)
+        {
+            // TODO: not ideal...
+            throw new NotImplementedException("The decorated API type is not customizable.");
+        }
+
+        return customizable.WithCustomization(requestCustomizer);
+    }
+
+    /// <inheritdoc/>
+    void IRestCustomizable.RemoveCustomization(RestRequestCustomization customization)
+    {
+        if (_actual is not IRestCustomizable customizable)
+        {
+            return;
+        }
+
+        customizable.RemoveCustomization(customization);
     }
 }

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestChannelAPI.Delegations.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestChannelAPI.Delegations.cs
@@ -1,0 +1,328 @@
+//
+//  CachingDiscordRestChannelAPI.Delegations.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Rest.Core;
+using Remora.Results;
+
+namespace Remora.Discord.Caching.API;
+
+public partial class CachingDiscordRestChannelAPI
+{
+    /// <inheritdoc />
+    public Task<Result<IChannel>> ModifyGroupDMChannelAsync
+    (
+        Snowflake channelID,
+        Optional<string> name = default,
+        Optional<Stream> icon = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.ModifyGroupDMChannelAsync(channelID, name, icon, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<IChannel>> ModifyGuildTextChannelAsync
+    (
+        Snowflake channelID,
+        Optional<string> name = default,
+        Optional<ChannelType> type = default,
+        Optional<int?> position = default,
+        Optional<string?> topic = default,
+        Optional<bool?> isNsfw = default,
+        Optional<int?> rateLimitPerUser = default,
+        Optional<IReadOnlyList<IPartialPermissionOverwrite>?> permissionOverwrites = default,
+        Optional<Snowflake?> parentId = default,
+        Optional<AutoArchiveDuration> defaultAutoArchiveDuration = default,
+        Optional<string> reason = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.ModifyGuildTextChannelAsync
+        (
+            channelID,
+            name,
+            type,
+            position,
+            topic,
+            isNsfw,
+            rateLimitPerUser,
+            permissionOverwrites,
+            parentId,
+            defaultAutoArchiveDuration,
+            reason,
+            ct
+        );
+    }
+
+    /// <inheritdoc />
+    public Task<Result<IChannel>> ModifyGuildVoiceChannelAsync
+    (
+        Snowflake channelID,
+        Optional<string> name = default,
+        Optional<int?> position = default,
+        Optional<int?> bitrate = default,
+        Optional<int?> userLimit = default,
+        Optional<IReadOnlyList<IPartialPermissionOverwrite>?> permissionOverwrites = default,
+        Optional<Snowflake?> parentId = default,
+        Optional<string?> rtcRegion = default,
+        Optional<VideoQualityMode?> videoQualityMode = default,
+        Optional<string> reason = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.ModifyGuildVoiceChannelAsync
+        (
+            channelID,
+            name,
+            position,
+            bitrate,
+            userLimit,
+            permissionOverwrites,
+            parentId,
+            rtcRegion,
+            videoQualityMode,
+            reason,
+            ct
+        );
+    }
+
+    /// <inheritdoc />
+    public Task<Result<IChannel>> ModifyGuildNewsChannelAsync
+    (
+        Snowflake channelID,
+        Optional<string> name = default,
+        Optional<ChannelType> type = default,
+        Optional<int?> position = default,
+        Optional<string?> topic = default,
+        Optional<bool?> isNsfw = default,
+        Optional<IReadOnlyList<IPartialPermissionOverwrite>?> permissionOverwrites = default,
+        Optional<Snowflake?> parentId = default,
+        Optional<string> reason = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.ModifyGuildNewsChannelAsync
+        (
+            channelID,
+            name,
+            type,
+            position,
+            topic,
+            isNsfw,
+            permissionOverwrites,
+            parentId,
+            reason,
+            ct
+        );
+    }
+
+    /// <inheritdoc />
+    public Task<Result<IChannel>> ModifyThreadChannelAsync
+    (
+        Snowflake channelID,
+        Optional<string> name = default,
+        Optional<bool> isArchived = default,
+        Optional<AutoArchiveDuration> autoArchiveDuration = default,
+        Optional<bool> isLocked = default,
+        Optional<int?> rateLimitPerUser = default,
+        Optional<string> reason = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.ModifyThreadChannelAsync
+        (
+            channelID,
+            name,
+            isArchived,
+            autoArchiveDuration,
+            isLocked,
+            rateLimitPerUser,
+            reason,
+            ct
+        );
+    }
+
+    /// <inheritdoc />
+    public Task<Result> CreateReactionAsync
+    (
+        Snowflake channelID,
+        Snowflake messageID,
+        string emoji,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.CreateReactionAsync(channelID, messageID, emoji, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> DeleteOwnReactionAsync
+    (
+        Snowflake channelID,
+        Snowflake messageID,
+        string emoji,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.DeleteOwnReactionAsync(channelID, messageID, emoji, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> DeleteUserReactionAsync
+    (
+        Snowflake channelID,
+        Snowflake messageID,
+        string emoji,
+        Snowflake user,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.DeleteUserReactionAsync(channelID, messageID, emoji, user, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<IReadOnlyList<IUser>>> GetReactionsAsync
+    (
+        Snowflake channelID,
+        Snowflake messageID,
+        string emoji,
+        Optional<Snowflake> after = default,
+        Optional<int> limit = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.GetReactionsAsync(channelID, messageID, emoji, after, limit, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> DeleteAllReactionsAsync
+    (
+        Snowflake channelID,
+        Snowflake messageID,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.DeleteAllReactionsAsync(channelID, messageID, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> DeleteAllReactionsForEmojiAsync
+    (
+        Snowflake channelID,
+        Snowflake messageID,
+        string emoji,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.DeleteAllReactionsForEmojiAsync(channelID, messageID, emoji, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> EditChannelPermissionsAsync
+    (
+        Snowflake channelID,
+        Snowflake overwriteID,
+        Optional<IDiscordPermissionSet> allow = default,
+        Optional<IDiscordPermissionSet> deny = default,
+        Optional<PermissionOverwriteType> type = default,
+        Optional<string> reason = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.EditChannelPermissionsAsync(channelID, overwriteID, allow, deny, type, reason, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<IFollowedChannel>> FollowNewsChannelAsync
+    (
+        Snowflake channelID,
+        Snowflake webhookChannelID,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.FollowNewsChannelAsync(channelID, webhookChannelID, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> TriggerTypingIndicatorAsync(Snowflake channelID, CancellationToken ct = default)
+    {
+        return _actual.TriggerTypingIndicatorAsync(channelID, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> PinMessageAsync
+    (
+        Snowflake channelID,
+        Snowflake messageID,
+        Optional<string> reason = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.PinMessageAsync(channelID, messageID, reason, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> GroupDMAddRecipientAsync
+    (
+        Snowflake channelID,
+        Snowflake userID,
+        string accessToken,
+        Optional<string> nickname = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.GroupDMAddRecipientAsync(channelID, userID, accessToken, nickname, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> GroupDMRemoveRecipientAsync
+    (
+        Snowflake channelID,
+        Snowflake userID,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.GroupDMRemoveRecipientAsync(channelID, userID, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> JoinThreadAsync(Snowflake channelID, CancellationToken ct = default)
+    {
+        return _actual.JoinThreadAsync(channelID, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> AddThreadMemberAsync(Snowflake channelID, Snowflake userID, CancellationToken ct = default)
+    {
+        return _actual.AddThreadMemberAsync(channelID, userID, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> LeaveThreadAsync(Snowflake channelID, CancellationToken ct = default)
+    {
+        return _actual.LeaveThreadAsync(channelID, ct);
+    }
+}

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestChannelAPI.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestChannelAPI.cs
@@ -23,7 +23,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -31,38 +30,38 @@ using OneOf;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Abstractions.Rest;
 using Remora.Discord.API.Objects;
-using Remora.Discord.Caching.Abstractions.Services;
 using Remora.Discord.Caching.Services;
-using Remora.Discord.Rest.API;
-using Remora.Rest;
 using Remora.Rest.Core;
 using Remora.Results;
 
 namespace Remora.Discord.Caching.API;
 
 /// <summary>
-/// Implements a caching version of the channel API.
+/// Decorates the registered channel API with caching functionality.
 /// </summary>
 [PublicAPI]
-public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
+public partial class CachingDiscordRestChannelAPI : IDiscordRestChannelAPI
 {
+    private readonly IDiscordRestChannelAPI _actual;
     private readonly CacheService _cacheService;
 
-    /// <inheritdoc cref="DiscordRestChannelAPI(IRestHttpClient, JsonSerializerOptions, ICacheProvider)" />
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CachingDiscordRestChannelAPI"/> class.
+    /// </summary>
+    /// <param name="actual">The decorated instance.</param>
+    /// <param name="cacheService">The cache service.</param>
     public CachingDiscordRestChannelAPI
     (
-        IRestHttpClient restHttpClient,
-        JsonSerializerOptions jsonOptions,
-        ICacheProvider rateLimitCache,
+        IDiscordRestChannelAPI actual,
         CacheService cacheService
     )
-        : base(restHttpClient, jsonOptions, rateLimitCache)
     {
+        _actual = actual;
         _cacheService = cacheService;
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IChannel>> GetChannelAsync
+    public async Task<Result<IChannel>> GetChannelAsync
     (
         Snowflake channelID,
         CancellationToken ct = default
@@ -77,7 +76,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
             return Result<IChannel>.FromSuccess(cacheResult.Entity);
         }
 
-        var getChannel = await base.GetChannelAsync(channelID, ct);
+        var getChannel = await _actual.GetChannelAsync(channelID, ct);
         if (!getChannel.IsSuccess)
         {
             return getChannel;
@@ -90,7 +89,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IChannel>> ModifyChannelAsync
+    public async Task<Result<IChannel>> ModifyChannelAsync
     (
         Snowflake channelID,
         Optional<string> name = default,
@@ -114,7 +113,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
         CancellationToken ct = default
     )
     {
-        var modificationResult = await base.ModifyChannelAsync
+        var modificationResult = await _actual.ModifyChannelAsync
         (
             channelID,
             name,
@@ -151,14 +150,14 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result> DeleteChannelAsync
+    public async Task<Result> DeleteChannelAsync
     (
         Snowflake channelID,
         Optional<string> reason = default,
         CancellationToken ct = default
     )
     {
-        var deleteResult = await base.DeleteChannelAsync(channelID, reason, ct);
+        var deleteResult = await _actual.DeleteChannelAsync(channelID, reason, ct);
         if (!deleteResult.IsSuccess)
         {
             return deleteResult;
@@ -171,7 +170,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IMessage>> GetChannelMessageAsync
+    public async Task<Result<IMessage>> GetChannelMessageAsync
     (
         Snowflake channelID,
         Snowflake messageID,
@@ -186,7 +185,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
             return Result<IMessage>.FromSuccess(cacheResult.Entity);
         }
 
-        var getMessage = await base.GetChannelMessageAsync(channelID, messageID, ct);
+        var getMessage = await _actual.GetChannelMessageAsync(channelID, messageID, ct);
         if (!getMessage.IsSuccess)
         {
             return getMessage;
@@ -199,7 +198,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IMessage>> CreateMessageAsync
+    public async Task<Result<IMessage>> CreateMessageAsync
     (
         Snowflake channelID,
         Optional<string> content = default,
@@ -215,7 +214,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
         CancellationToken ct = default
     )
     {
-        var createResult = await base.CreateMessageAsync
+        var createResult = await _actual.CreateMessageAsync
         (
             channelID,
             content,
@@ -244,7 +243,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IMessage>> EditMessageAsync
+    public async Task<Result<IMessage>> EditMessageAsync
     (
         Snowflake channelID,
         Snowflake messageID,
@@ -257,7 +256,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
         CancellationToken ct = default
     )
     {
-        var editResult = await base.EditMessageAsync
+        var editResult = await _actual.EditMessageAsync
         (
             channelID,
             messageID,
@@ -283,7 +282,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result> DeleteMessageAsync
+    public async Task<Result> DeleteMessageAsync
     (
         Snowflake channelID,
         Snowflake messageID,
@@ -291,7 +290,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
         CancellationToken ct = default
     )
     {
-        var deleteResult = await base.DeleteMessageAsync(channelID, messageID, reason, ct);
+        var deleteResult = await _actual.DeleteMessageAsync(channelID, messageID, reason, ct);
         if (!deleteResult.IsSuccess)
         {
             return deleteResult;
@@ -304,7 +303,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result> BulkDeleteMessagesAsync
+    public async Task<Result> BulkDeleteMessagesAsync
     (
         Snowflake channelID,
         IReadOnlyList<Snowflake> messageIDs,
@@ -312,7 +311,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
         CancellationToken ct = default
     )
     {
-        var deleteResult = await base.BulkDeleteMessagesAsync(channelID, messageIDs, reason, ct);
+        var deleteResult = await _actual.BulkDeleteMessagesAsync(channelID, messageIDs, reason, ct);
         if (!deleteResult.IsSuccess)
         {
             return deleteResult;
@@ -328,7 +327,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IInvite>> CreateChannelInviteAsync
+    public async Task<Result<IInvite>> CreateChannelInviteAsync
     (
         Snowflake channelID,
         Optional<TimeSpan> maxAge = default,
@@ -342,7 +341,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
         CancellationToken ct = default
     )
     {
-        var createResult = await base.CreateChannelInviteAsync
+        var createResult = await _actual.CreateChannelInviteAsync
         (
             channelID,
             maxAge,
@@ -369,7 +368,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result> DeleteChannelPermissionAsync
+    public async Task<Result> DeleteChannelPermissionAsync
     (
         Snowflake channelID,
         Snowflake overwriteID,
@@ -377,7 +376,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
         CancellationToken ct = default
     )
     {
-        var deleteResult = await base.DeleteChannelPermissionAsync(channelID, overwriteID, reason, ct);
+        var deleteResult = await _actual.DeleteChannelPermissionAsync(channelID, overwriteID, reason, ct);
         if (!deleteResult.IsSuccess)
         {
             return deleteResult;
@@ -390,7 +389,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IReadOnlyList<IMessage>>> GetPinnedMessagesAsync
+    public async Task<Result<IReadOnlyList<IMessage>>> GetPinnedMessagesAsync
     (
         Snowflake channelID,
         CancellationToken ct = default
@@ -405,7 +404,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
             return Result<IReadOnlyList<IMessage>>.FromSuccess(cacheResult.Entity);
         }
 
-        var getResult = await base.GetPinnedMessagesAsync(channelID, ct);
+        var getResult = await _actual.GetPinnedMessagesAsync(channelID, ct);
         if (!getResult.IsSuccess)
         {
             return getResult;
@@ -424,7 +423,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result> UnpinMessageAsync
+    public async Task<Result> UnpinMessageAsync
     (
         Snowflake channelID,
         Snowflake messageID,
@@ -432,7 +431,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
         CancellationToken ct = default
     )
     {
-        var deleteResult = await base.UnpinMessageAsync(channelID, messageID, reason, ct);
+        var deleteResult = await _actual.UnpinMessageAsync(channelID, messageID, reason, ct);
         if (!deleteResult.IsSuccess)
         {
             return deleteResult;
@@ -445,7 +444,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IChannel>> StartThreadWithMessageAsync
+    public async Task<Result<IChannel>> StartThreadWithMessageAsync
     (
         Snowflake channelID,
         Snowflake messageID,
@@ -456,7 +455,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
         CancellationToken ct = default
     )
     {
-        var createResult = await base.StartThreadWithMessageAsync
+        var createResult = await _actual.StartThreadWithMessageAsync
         (
             channelID,
             messageID,
@@ -479,7 +478,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IChannel>> StartThreadWithoutMessageAsync
+    public async Task<Result<IChannel>> StartThreadWithoutMessageAsync
     (
         Snowflake channelID,
         string name,
@@ -491,7 +490,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
         CancellationToken ct = default
     )
     {
-        var createResult = await base.StartThreadWithoutMessageAsync
+        var createResult = await _actual.StartThreadWithoutMessageAsync
         (
             channelID,
             name,
@@ -515,7 +514,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IReadOnlyList<IMessage>>> GetChannelMessagesAsync
+    public async Task<Result<IReadOnlyList<IMessage>>> GetChannelMessagesAsync
     (
         Snowflake channelID,
         Optional<Snowflake> around = default,
@@ -525,7 +524,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
         CancellationToken ct = default
     )
     {
-        var getResult = await base.GetChannelMessagesAsync(channelID, around, before, after, limit, ct);
+        var getResult = await _actual.GetChannelMessagesAsync(channelID, around, before, after, limit, ct);
         if (!getResult.IsSuccess)
         {
             return getResult;
@@ -541,14 +540,14 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IMessage>> CrosspostMessageAsync
+    public async Task<Result<IMessage>> CrosspostMessageAsync
     (
         Snowflake channelID,
         Snowflake messageID,
         CancellationToken ct = default
     )
     {
-        var result = await base.CrosspostMessageAsync(channelID, messageID, ct);
+        var result = await _actual.CrosspostMessageAsync(channelID, messageID, ct);
         if (!result.IsSuccess)
         {
             return result;
@@ -562,7 +561,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IReadOnlyList<IInvite>>> GetChannelInvitesAsync
+    public async Task<Result<IReadOnlyList<IInvite>>> GetChannelInvitesAsync
     (
         Snowflake channelID,
         CancellationToken ct = default
@@ -577,7 +576,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
             return Result<IReadOnlyList<IInvite>>.FromSuccess(cacheResult.Entity);
         }
 
-        var result = await base.GetChannelInvitesAsync(channelID, ct);
+        var result = await _actual.GetChannelInvitesAsync(channelID, ct);
         if (!result.IsSuccess)
         {
             return result;
@@ -595,7 +594,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IThreadMember>> GetThreadMemberAsync
+    public async Task<Result<IThreadMember>> GetThreadMemberAsync
     (
         Snowflake channelID,
         Snowflake userID,
@@ -611,7 +610,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
             return Result<IThreadMember>.FromSuccess(cacheResult.Entity);
         }
 
-        var result = await base.GetThreadMemberAsync(channelID, userID, ct);
+        var result = await _actual.GetThreadMemberAsync(channelID, userID, ct);
         if (!result.IsSuccess)
         {
             return result;
@@ -624,7 +623,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IReadOnlyList<IThreadMember>>> ListThreadMembersAsync
+    public async Task<Result<IReadOnlyList<IThreadMember>>> ListThreadMembersAsync
     (
         Snowflake channelID,
         CancellationToken ct = default
@@ -639,7 +638,7 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
             return Result<IReadOnlyList<IThreadMember>>.FromSuccess(cacheResult.Entity);
         }
 
-        var result = await base.ListThreadMembersAsync(channelID, ct);
+        var result = await _actual.ListThreadMembersAsync(channelID, ct);
         if (!result.IsSuccess)
         {
             return result;
@@ -660,14 +659,14 @@ public class CachingDiscordRestChannelAPI : DiscordRestChannelAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result> RemoveThreadMemberAsync
+    public async Task<Result> RemoveThreadMemberAsync
     (
         Snowflake channelID,
         Snowflake userID,
         CancellationToken ct = default
     )
     {
-        var result = await base.RemoveThreadMemberAsync(channelID, userID, ct);
+        var result = await _actual.RemoveThreadMemberAsync(channelID, userID, ct);
         if (!result.IsSuccess)
         {
             return result;

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestChannelAPI.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestChannelAPI.cs
@@ -31,6 +31,7 @@ using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Abstractions.Rest;
 using Remora.Discord.API.Objects;
 using Remora.Discord.Caching.Services;
+using Remora.Rest;
 using Remora.Rest.Core;
 using Remora.Results;
 
@@ -40,7 +41,7 @@ namespace Remora.Discord.Caching.API;
 /// Decorates the registered channel API with caching functionality.
 /// </summary>
 [PublicAPI]
-public partial class CachingDiscordRestChannelAPI : IDiscordRestChannelAPI
+public partial class CachingDiscordRestChannelAPI : IDiscordRestChannelAPI, IRestCustomizable
 {
     private readonly IDiscordRestChannelAPI _actual;
     private readonly CacheService _cacheService;

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestEmojiAPI.Delegations.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestEmojiAPI.Delegations.cs
@@ -1,5 +1,5 @@
 //
-//  CachingDiscordRestInteractionAPI.Delegations.cs
+//  CachingDiscordRestEmojiAPI.Delegations.cs
 //
 //  Author:
 //       Jarl Gullberg <jarl.gullberg@gmail.com>
@@ -21,33 +21,12 @@
 //
 
 using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using OneOf;
-using Remora.Discord.API.Abstractions.Objects;
-using Remora.Discord.API.Abstractions.Rest;
 using Remora.Rest;
-using Remora.Rest.Core;
-using Remora.Results;
 
 namespace Remora.Discord.Caching.API;
 
-public partial class CachingDiscordRestInteractionAPI
+public partial class CachingDiscordRestEmojiAPI
 {
-    /// <inheritdoc />
-    public Task<Result> CreateInteractionResponseAsync
-    (
-        Snowflake interactionID,
-        string interactionToken,
-        IInteractionResponse response,
-        Optional<IReadOnlyList<OneOf<FileData, IPartialAttachment>>> attachments = default,
-        CancellationToken ct = default
-    )
-    {
-        return _actual.CreateInteractionResponseAsync(interactionID, interactionToken, response, attachments, ct);
-    }
-
     /// <inheritdoc/>
     public RestRequestCustomization WithCustomization(Action<RestRequestBuilder> requestCustomizer)
     {

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestEmojiAPI.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestEmojiAPI.cs
@@ -22,43 +22,43 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
-using Remora.Discord.Caching.Abstractions.Services;
+using Remora.Discord.API.Abstractions.Rest;
 using Remora.Discord.Caching.Services;
-using Remora.Discord.Rest.API;
-using Remora.Rest;
 using Remora.Rest.Core;
 using Remora.Results;
 
 namespace Remora.Discord.Caching.API;
 
 /// <summary>
-/// Implements a caching version of the channel API.
+/// Decorates the registered emoji API with caching functionality.
 /// </summary>
 [PublicAPI]
-public class CachingDiscordRestEmojiAPI : DiscordRestEmojiAPI
+public class CachingDiscordRestEmojiAPI : IDiscordRestEmojiAPI
 {
+    private readonly IDiscordRestEmojiAPI _actual;
     private readonly CacheService _cacheService;
 
-    /// <inheritdoc cref="DiscordRestEmojiAPI(IRestHttpClient, JsonSerializerOptions, ICacheProvider)" />
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CachingDiscordRestEmojiAPI"/> class.
+    /// </summary>
+    /// <param name="actual">The decorated instance.</param>
+    /// <param name="cacheService">The cache service.</param>
     public CachingDiscordRestEmojiAPI
     (
-        IRestHttpClient restHttpClient,
-        JsonSerializerOptions jsonOptions,
-        ICacheProvider rateLimitCache,
+        IDiscordRestEmojiAPI actual,
         CacheService cacheService
     )
-        : base(restHttpClient, jsonOptions, rateLimitCache)
     {
+        _actual = actual;
         _cacheService = cacheService;
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IEmoji>> GetGuildEmojiAsync
+    public async Task<Result<IEmoji>> GetGuildEmojiAsync
     (
         Snowflake guildID,
         Snowflake emojiID,
@@ -73,7 +73,7 @@ public class CachingDiscordRestEmojiAPI : DiscordRestEmojiAPI
             return Result<IEmoji>.FromSuccess(cacheResult.Entity);
         }
 
-        var getResult = await base.GetGuildEmojiAsync(guildID, emojiID, ct);
+        var getResult = await _actual.GetGuildEmojiAsync(guildID, emojiID, ct);
         if (!getResult.IsSuccess)
         {
             return getResult;
@@ -86,7 +86,7 @@ public class CachingDiscordRestEmojiAPI : DiscordRestEmojiAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IEmoji>> CreateGuildEmojiAsync
+    public async Task<Result<IEmoji>> CreateGuildEmojiAsync
     (
         Snowflake guildID,
         string name,
@@ -96,7 +96,7 @@ public class CachingDiscordRestEmojiAPI : DiscordRestEmojiAPI
         CancellationToken ct = default
     )
     {
-        var createResult = await base.CreateGuildEmojiAsync(guildID, name, image, roles, reason, ct);
+        var createResult = await _actual.CreateGuildEmojiAsync(guildID, name, image, roles, reason, ct);
         if (!createResult.IsSuccess)
         {
             return createResult;
@@ -116,7 +116,7 @@ public class CachingDiscordRestEmojiAPI : DiscordRestEmojiAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IEmoji>> ModifyGuildEmojiAsync
+    public async Task<Result<IEmoji>> ModifyGuildEmojiAsync
     (
         Snowflake guildID,
         Snowflake emojiID,
@@ -126,7 +126,7 @@ public class CachingDiscordRestEmojiAPI : DiscordRestEmojiAPI
         CancellationToken ct = default
     )
     {
-        var modifyResult = await base.ModifyGuildEmojiAsync(guildID, emojiID, name, roles, reason, ct);
+        var modifyResult = await _actual.ModifyGuildEmojiAsync(guildID, emojiID, name, roles, reason, ct);
         if (!modifyResult.IsSuccess)
         {
             return modifyResult;
@@ -140,7 +140,7 @@ public class CachingDiscordRestEmojiAPI : DiscordRestEmojiAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result> DeleteGuildEmojiAsync
+    public async Task<Result> DeleteGuildEmojiAsync
     (
         Snowflake guildID,
         Snowflake emojiID,
@@ -148,7 +148,7 @@ public class CachingDiscordRestEmojiAPI : DiscordRestEmojiAPI
         CancellationToken ct = default
     )
     {
-        var deleteResult = await base.DeleteGuildEmojiAsync(guildID, emojiID, reason, ct);
+        var deleteResult = await _actual.DeleteGuildEmojiAsync(guildID, emojiID, reason, ct);
         if (!deleteResult.IsSuccess)
         {
             return deleteResult;
@@ -161,7 +161,7 @@ public class CachingDiscordRestEmojiAPI : DiscordRestEmojiAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IReadOnlyList<IEmoji>>> ListGuildEmojisAsync
+    public async Task<Result<IReadOnlyList<IEmoji>>> ListGuildEmojisAsync
     (
         Snowflake guildID,
         CancellationToken ct = default
@@ -175,7 +175,7 @@ public class CachingDiscordRestEmojiAPI : DiscordRestEmojiAPI
             return Result<IReadOnlyList<IEmoji>>.FromSuccess(cacheResult.Entity);
         }
 
-        var result = await base.ListGuildEmojisAsync(guildID, ct);
+        var result = await _actual.ListGuildEmojisAsync(guildID, ct);
         if (!result.IsSuccess)
         {
             return result;

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestEmojiAPI.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestEmojiAPI.cs
@@ -28,6 +28,7 @@ using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Abstractions.Rest;
 using Remora.Discord.Caching.Services;
+using Remora.Rest;
 using Remora.Rest.Core;
 using Remora.Results;
 
@@ -37,7 +38,7 @@ namespace Remora.Discord.Caching.API;
 /// Decorates the registered emoji API with caching functionality.
 /// </summary>
 [PublicAPI]
-public class CachingDiscordRestEmojiAPI : IDiscordRestEmojiAPI
+public partial class CachingDiscordRestEmojiAPI : IDiscordRestEmojiAPI, IRestCustomizable
 {
     private readonly IDiscordRestEmojiAPI _actual;
     private readonly CacheService _cacheService;

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestGuildAPI.Delegations.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestGuildAPI.Delegations.cs
@@ -26,6 +26,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Remora.Discord.API.Abstractions.Objects;
+using Remora.Rest;
 using Remora.Rest.Core;
 using Remora.Results;
 
@@ -211,5 +212,28 @@ public partial class CachingDiscordRestGuildAPI
     )
     {
         return _actual.ModifyUserVoiceStateAsync(guildID, userID, channelID, suppress, ct);
+    }
+
+    /// <inheritdoc/>
+    public RestRequestCustomization WithCustomization(Action<RestRequestBuilder> requestCustomizer)
+    {
+        if (_actual is not IRestCustomizable customizable)
+        {
+            // TODO: not ideal...
+            throw new NotImplementedException("The decorated API type is not customizable.");
+        }
+
+        return customizable.WithCustomization(requestCustomizer);
+    }
+
+    /// <inheritdoc/>
+    void IRestCustomizable.RemoveCustomization(RestRequestCustomization customization)
+    {
+        if (_actual is not IRestCustomizable customizable)
+        {
+            return;
+        }
+
+        customizable.RemoveCustomization(customization);
     }
 }

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestGuildAPI.Delegations.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestGuildAPI.Delegations.cs
@@ -1,0 +1,215 @@
+//
+//  CachingDiscordRestGuildAPI.Delegations.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Rest.Core;
+using Remora.Results;
+
+namespace Remora.Discord.Caching.API;
+
+public partial class CachingDiscordRestGuildAPI
+{
+    /// <inheritdoc />
+    public Task<Result> ModifyGuildChannelPositionsAsync
+    (
+        Snowflake guildID,
+        IReadOnlyList<(Snowflake ChannelID, int? Position, bool? LockPermissions, Snowflake? ParentID)> positionModifications,
+        Optional<string> reason = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.ModifyGuildChannelPositionsAsync(guildID, positionModifications, reason, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<IGuildThreadQueryResponse>> ListActiveThreadsAsync
+    (
+        Snowflake guildID,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.ListActiveThreadsAsync(guildID, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> ModifyGuildMemberAsync
+    (
+        Snowflake guildID,
+        Snowflake userID,
+        Optional<string?> nickname = default,
+        Optional<IReadOnlyList<Snowflake>?> roles = default,
+        Optional<bool?> isMuted = default,
+        Optional<bool?> isDeafened = default,
+        Optional<Snowflake?> channelID = default,
+        Optional<DateTimeOffset?> communicationDisabledUntil = default,
+        Optional<string> reason = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.ModifyGuildMemberAsync
+        (
+            guildID,
+            userID,
+            nickname,
+            roles,
+            isMuted,
+            isDeafened,
+            channelID,
+            communicationDisabledUntil,
+            reason,
+            ct
+        );
+    }
+
+    /// <inheritdoc />
+    public Task<Result> AddGuildMemberRoleAsync
+    (
+        Snowflake guildID,
+        Snowflake userID,
+        Snowflake roleID,
+        Optional<string> reason = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.AddGuildMemberRoleAsync(guildID, userID, roleID, reason, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> RemoveGuildMemberRoleAsync
+    (
+        Snowflake guildID,
+        Snowflake userID,
+        Snowflake roleID,
+        Optional<string> reason = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.RemoveGuildMemberRoleAsync(guildID, userID, roleID, reason, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> CreateGuildBanAsync
+    (
+        Snowflake guildID,
+        Snowflake userID,
+        Optional<int> deleteMessageDays = default,
+        Optional<string> reason = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.CreateGuildBanAsync(guildID, userID, deleteMessageDays, reason, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<IPruneCount>> GetGuildPruneCountAsync
+    (
+        Snowflake guildID,
+        Optional<int> days = default,
+        Optional<IReadOnlyList<Snowflake>> includeRoles = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.GetGuildPruneCountAsync(guildID, days, includeRoles, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<IPruneCount>> BeginGuildPruneAsync
+    (
+        Snowflake guildID,
+        Optional<int> days = default,
+        Optional<bool> computePruneCount = default,
+        Optional<IReadOnlyList<Snowflake>> includeRoles = default,
+        Optional<string> reason = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.BeginGuildPruneAsync(guildID, days, computePruneCount, includeRoles, reason, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<IGuildWidget>> GetGuildWidgetAsync(Snowflake guildID, CancellationToken ct = default)
+    {
+        return _actual.GetGuildWidgetAsync(guildID, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<IPartialInvite>> GetGuildVanityUrlAsync(Snowflake guildID, CancellationToken ct = default)
+    {
+        return _actual.GetGuildVanityUrlAsync(guildID, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<Stream>> GetGuildWidgetImageAsync
+    (
+        Snowflake guildID,
+        Optional<WidgetImageStyle> style = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.GetGuildWidgetImageAsync(guildID, style, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<IWelcomeScreen>> ModifyGuildWelcomeScreenAsync
+    (
+        Snowflake guildID,
+        Optional<bool?> isEnabled = default,
+        Optional<IReadOnlyList<IWelcomeScreenChannel>?> welcomeChannels = default,
+        Optional<string?> description = default,
+        Optional<string> reason = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.ModifyGuildWelcomeScreenAsync(guildID, isEnabled, welcomeChannels, description, reason, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> ModifyCurrentUserVoiceStateAsync
+    (
+        Snowflake guildID,
+        Snowflake channelID,
+        Optional<bool> suppress = default,
+        Optional<DateTimeOffset?> requestToSpeakTimestamp = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.ModifyCurrentUserVoiceStateAsync(guildID, channelID, suppress, requestToSpeakTimestamp, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result<IVoiceState>> ModifyUserVoiceStateAsync
+    (
+        Snowflake guildID,
+        Snowflake userID,
+        Snowflake channelID,
+        Optional<bool> suppress = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.ModifyUserVoiceStateAsync(guildID, userID, channelID, suppress, ct);
+    }
+}

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestGuildAPI.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestGuildAPI.cs
@@ -30,6 +30,7 @@ using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Abstractions.Rest;
 using Remora.Discord.Caching.Services;
+using Remora.Rest;
 using Remora.Rest.Core;
 using Remora.Results;
 
@@ -39,7 +40,7 @@ namespace Remora.Discord.Caching.API;
 /// Decorates the registered guild API with caching functionality.
 /// </summary>
 [PublicAPI]
-public partial class CachingDiscordRestGuildAPI : IDiscordRestGuildAPI
+public partial class CachingDiscordRestGuildAPI : IDiscordRestGuildAPI, IRestCustomizable
 {
     private readonly IDiscordRestGuildAPI _actual;
     private readonly CacheService _cacheService;

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestInteractionAPI.Delegations.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestInteractionAPI.Delegations.cs
@@ -1,0 +1,48 @@
+//
+//  CachingDiscordRestInteractionAPI.Delegations.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using OneOf;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.API.Abstractions.Rest;
+using Remora.Rest.Core;
+using Remora.Results;
+
+namespace Remora.Discord.Caching.API;
+
+public partial class CachingDiscordRestInteractionAPI
+{
+    /// <inheritdoc />
+    public Task<Result> CreateInteractionResponseAsync
+    (
+        Snowflake interactionID,
+        string interactionToken,
+        IInteractionResponse response,
+        Optional<IReadOnlyList<OneOf<FileData, IPartialAttachment>>> attachments = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.CreateInteractionResponseAsync(interactionID, interactionToken, response, attachments, ct);
+    }
+}

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestInteractionAPI.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestInteractionAPI.cs
@@ -21,43 +21,44 @@
 //
 
 using System.Collections.Generic;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using OneOf;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Abstractions.Rest;
-using Remora.Discord.Caching.Abstractions.Services;
 using Remora.Discord.Caching.Services;
-using Remora.Discord.Rest.API;
-using Remora.Rest;
 using Remora.Rest.Core;
 using Remora.Results;
 
 namespace Remora.Discord.Caching.API;
 
-/// <inheritdoc />
+/// <summary>
+/// Decorates the registered interaction API with caching functionality.
+/// </summary>
 [PublicAPI]
-public class CachingDiscordRestInteractionAPI : DiscordRestInteractionAPI
+public partial class CachingDiscordRestInteractionAPI : IDiscordRestInteractionAPI
 {
+    private readonly IDiscordRestInteractionAPI _actual;
     private readonly CacheService _cacheService;
 
-    /// <inheritdoc cref="DiscordRestInteractionAPI(IRestHttpClient, JsonSerializerOptions, ICacheProvider)" />
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CachingDiscordRestInteractionAPI"/> class.
+    /// </summary>
+    /// <param name="actual">The decorated instance.</param>
+    /// <param name="cacheService">The cache service.</param>
     public CachingDiscordRestInteractionAPI
     (
-        IRestHttpClient restHttpClient,
-        JsonSerializerOptions jsonOptions,
-        ICacheProvider rateLimitCache,
+        IDiscordRestInteractionAPI actual,
         CacheService cacheService
     )
-        : base(restHttpClient, jsonOptions, rateLimitCache)
     {
+        _actual = actual;
         _cacheService = cacheService;
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IMessage>> CreateFollowupMessageAsync
+    public async Task<Result<IMessage>> CreateFollowupMessageAsync
     (
         Snowflake applicationID,
         string token,
@@ -71,7 +72,7 @@ public class CachingDiscordRestInteractionAPI : DiscordRestInteractionAPI
         CancellationToken ct = default
     )
     {
-        var result = await base.CreateFollowupMessageAsync
+        var result = await _actual.CreateFollowupMessageAsync
         (
             applicationID,
             token,
@@ -102,7 +103,7 @@ public class CachingDiscordRestInteractionAPI : DiscordRestInteractionAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result> DeleteFollowupMessageAsync
+    public async Task<Result> DeleteFollowupMessageAsync
     (
         Snowflake applicationID,
         string token,
@@ -110,7 +111,7 @@ public class CachingDiscordRestInteractionAPI : DiscordRestInteractionAPI
         CancellationToken ct = default
     )
     {
-        var result = await base.DeleteFollowupMessageAsync(applicationID, token, messageID, ct);
+        var result = await _actual.DeleteFollowupMessageAsync(applicationID, token, messageID, ct);
         if (!result.IsSuccess)
         {
             return result;
@@ -123,7 +124,7 @@ public class CachingDiscordRestInteractionAPI : DiscordRestInteractionAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IMessage>> GetFollowupMessageAsync
+    public async Task<Result<IMessage>> GetFollowupMessageAsync
     (
         Snowflake applicationID,
         string token,
@@ -139,7 +140,7 @@ public class CachingDiscordRestInteractionAPI : DiscordRestInteractionAPI
             return Result<IMessage>.FromSuccess(cacheResult.Entity);
         }
 
-        var result = await base.GetFollowupMessageAsync(applicationID, token, messageID, ct);
+        var result = await _actual.GetFollowupMessageAsync(applicationID, token, messageID, ct);
         if (!result.IsSuccess)
         {
             return result;
@@ -151,7 +152,7 @@ public class CachingDiscordRestInteractionAPI : DiscordRestInteractionAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IMessage>> EditFollowupMessageAsync
+    public async Task<Result<IMessage>> EditFollowupMessageAsync
     (
         Snowflake applicationID,
         string token,
@@ -164,7 +165,7 @@ public class CachingDiscordRestInteractionAPI : DiscordRestInteractionAPI
         CancellationToken ct = default
     )
     {
-        var result = await base.EditFollowupMessageAsync
+        var result = await _actual.EditFollowupMessageAsync
         (
             applicationID,
             token,
@@ -189,7 +190,7 @@ public class CachingDiscordRestInteractionAPI : DiscordRestInteractionAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IMessage>> GetOriginalInteractionResponseAsync
+    public async Task<Result<IMessage>> GetOriginalInteractionResponseAsync
     (
         Snowflake applicationID,
         string interactionToken,
@@ -204,7 +205,7 @@ public class CachingDiscordRestInteractionAPI : DiscordRestInteractionAPI
             return Result<IMessage>.FromSuccess(cacheResult.Entity);
         }
 
-        var result = await base.GetOriginalInteractionResponseAsync(applicationID, interactionToken, ct);
+        var result = await _actual.GetOriginalInteractionResponseAsync(applicationID, interactionToken, ct);
         if (!result.IsSuccess)
         {
             return result;
@@ -221,7 +222,7 @@ public class CachingDiscordRestInteractionAPI : DiscordRestInteractionAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IMessage>> EditOriginalInteractionResponseAsync
+    public async Task<Result<IMessage>> EditOriginalInteractionResponseAsync
     (
         Snowflake applicationID,
         string token,
@@ -233,7 +234,7 @@ public class CachingDiscordRestInteractionAPI : DiscordRestInteractionAPI
         CancellationToken ct = default
     )
     {
-        var result = await base.EditOriginalInteractionResponseAsync
+        var result = await _actual.EditOriginalInteractionResponseAsync
         (
             applicationID,
             token,
@@ -262,14 +263,14 @@ public class CachingDiscordRestInteractionAPI : DiscordRestInteractionAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result> DeleteOriginalInteractionResponseAsync
+    public async Task<Result> DeleteOriginalInteractionResponseAsync
     (
         Snowflake applicationID,
         string token,
         CancellationToken ct = default
     )
     {
-        var result = await base.DeleteOriginalInteractionResponseAsync(applicationID, token, ct);
+        var result = await _actual.DeleteOriginalInteractionResponseAsync(applicationID, token, ct);
         if (!result.IsSuccess)
         {
             return result;

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestInteractionAPI.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestInteractionAPI.cs
@@ -28,6 +28,7 @@ using OneOf;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Abstractions.Rest;
 using Remora.Discord.Caching.Services;
+using Remora.Rest;
 using Remora.Rest.Core;
 using Remora.Results;
 
@@ -37,7 +38,7 @@ namespace Remora.Discord.Caching.API;
 /// Decorates the registered interaction API with caching functionality.
 /// </summary>
 [PublicAPI]
-public partial class CachingDiscordRestInteractionAPI : IDiscordRestInteractionAPI
+public partial class CachingDiscordRestInteractionAPI : IDiscordRestInteractionAPI, IRestCustomizable
 {
     private readonly IDiscordRestInteractionAPI _actual;
     private readonly CacheService _cacheService;

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestInviteAPI.Delegations.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestInviteAPI.Delegations.cs
@@ -1,5 +1,5 @@
 //
-//  CachingDiscordRestInteractionAPI.Delegations.cs
+//  CachingDiscordRestInviteAPI.Delegations.cs
 //
 //  Author:
 //       Jarl Gullberg <jarl.gullberg@gmail.com>
@@ -21,33 +21,12 @@
 //
 
 using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using OneOf;
-using Remora.Discord.API.Abstractions.Objects;
-using Remora.Discord.API.Abstractions.Rest;
 using Remora.Rest;
-using Remora.Rest.Core;
-using Remora.Results;
 
 namespace Remora.Discord.Caching.API;
 
-public partial class CachingDiscordRestInteractionAPI
+public partial class CachingDiscordRestInviteAPI
 {
-    /// <inheritdoc />
-    public Task<Result> CreateInteractionResponseAsync
-    (
-        Snowflake interactionID,
-        string interactionToken,
-        IInteractionResponse response,
-        Optional<IReadOnlyList<OneOf<FileData, IPartialAttachment>>> attachments = default,
-        CancellationToken ct = default
-    )
-    {
-        return _actual.CreateInteractionResponseAsync(interactionID, interactionToken, response, attachments, ct);
-    }
-
     /// <inheritdoc/>
     public RestRequestCustomization WithCustomization(Action<RestRequestBuilder> requestCustomizer)
     {

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestInviteAPI.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestInviteAPI.cs
@@ -26,6 +26,7 @@ using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Abstractions.Rest;
 using Remora.Discord.Caching.Services;
+using Remora.Rest;
 using Remora.Rest.Core;
 using Remora.Results;
 
@@ -35,7 +36,7 @@ namespace Remora.Discord.Caching.API;
 /// Decorates the registered invite API with caching functionality.
 /// </summary>
 [PublicAPI]
-public class CachingDiscordRestInviteAPI : IDiscordRestInviteAPI
+public partial class CachingDiscordRestInviteAPI : IDiscordRestInviteAPI, IRestCustomizable
 {
     private readonly IDiscordRestInviteAPI _actual;
     private readonly CacheService _cacheService;

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestOAuth2API.Delegations.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestOAuth2API.Delegations.cs
@@ -1,5 +1,5 @@
 //
-//  CachingDiscordRestInteractionAPI.Delegations.cs
+//  CachingDiscordRestOAuth2API.Delegations.cs
 //
 //  Author:
 //       Jarl Gullberg <jarl.gullberg@gmail.com>
@@ -21,33 +21,12 @@
 //
 
 using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using OneOf;
-using Remora.Discord.API.Abstractions.Objects;
-using Remora.Discord.API.Abstractions.Rest;
 using Remora.Rest;
-using Remora.Rest.Core;
-using Remora.Results;
 
 namespace Remora.Discord.Caching.API;
 
-public partial class CachingDiscordRestInteractionAPI
+public partial class CachingDiscordRestOAuth2API
 {
-    /// <inheritdoc />
-    public Task<Result> CreateInteractionResponseAsync
-    (
-        Snowflake interactionID,
-        string interactionToken,
-        IInteractionResponse response,
-        Optional<IReadOnlyList<OneOf<FileData, IPartialAttachment>>> attachments = default,
-        CancellationToken ct = default
-    )
-    {
-        return _actual.CreateInteractionResponseAsync(interactionID, interactionToken, response, attachments, ct);
-    }
-
     /// <inheritdoc/>
     public RestRequestCustomization WithCustomization(Action<RestRequestBuilder> requestCustomizer)
     {

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestOAuth2API.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestOAuth2API.cs
@@ -20,40 +20,42 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
-using Remora.Discord.Caching.Abstractions.Services;
+using Remora.Discord.API.Abstractions.Rest;
 using Remora.Discord.Caching.Services;
-using Remora.Discord.Rest.API;
-using Remora.Rest;
 using Remora.Results;
 
 namespace Remora.Discord.Caching.API;
 
-/// <inheritdoc />
+/// <summary>
+/// Decorates the registered OAuth2 API with caching functionality.
+/// </summary>
 [PublicAPI]
-public class CachingDiscordRestOAuth2API : DiscordRestOAuth2API
+public class CachingDiscordRestOAuth2API : IDiscordRestOAuth2API
 {
+    private readonly IDiscordRestOAuth2API _actual;
     private readonly CacheService _cacheService;
 
-    /// <inheritdoc cref="DiscordRestOAuth2API(IRestHttpClient, JsonSerializerOptions, ICacheProvider)" />
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CachingDiscordRestOAuth2API"/> class.
+    /// </summary>
+    /// <param name="actual">The decorated instance.</param>
+    /// <param name="cacheService">The cache service.</param>
     public CachingDiscordRestOAuth2API
     (
-        IRestHttpClient restHttpClient,
-        JsonSerializerOptions jsonOptions,
-        ICacheProvider rateLimitCache,
+        IDiscordRestOAuth2API actual,
         CacheService cacheService
     )
-        : base(restHttpClient, jsonOptions, rateLimitCache)
     {
+        _actual = actual;
         _cacheService = cacheService;
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IApplication>> GetCurrentBotApplicationInformationAsync
+    public async Task<Result<IApplication>> GetCurrentBotApplicationInformationAsync
     (
         CancellationToken ct = default
     )
@@ -66,7 +68,7 @@ public class CachingDiscordRestOAuth2API : DiscordRestOAuth2API
             return Result<IApplication>.FromSuccess(cacheResult.Entity);
         }
 
-        var getCurrent = await base.GetCurrentBotApplicationInformationAsync(ct);
+        var getCurrent = await _actual.GetCurrentBotApplicationInformationAsync(ct);
         if (!getCurrent.IsSuccess)
         {
             return getCurrent;
@@ -79,7 +81,7 @@ public class CachingDiscordRestOAuth2API : DiscordRestOAuth2API
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IAuthorizationInformation>> GetCurrentAuthorizationInformationAsync
+    public async Task<Result<IAuthorizationInformation>> GetCurrentAuthorizationInformationAsync
     (
         CancellationToken ct = default
     )
@@ -92,7 +94,7 @@ public class CachingDiscordRestOAuth2API : DiscordRestOAuth2API
             return Result<IAuthorizationInformation>.FromSuccess(cacheResult.Entity);
         }
 
-        var result = await base.GetCurrentAuthorizationInformationAsync(ct);
+        var result = await _actual.GetCurrentAuthorizationInformationAsync(ct);
         if (!result.IsSuccess)
         {
             return result;

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestRestOAuth2API.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestRestOAuth2API.cs
@@ -1,5 +1,5 @@
 //
-//  CachingDiscordRestOAuth2API.cs
+//  CachingDiscordRestRestOAuth2API.cs
 //
 //  Author:
 //       Jarl Gullberg <jarl.gullberg@gmail.com>
@@ -26,6 +26,7 @@ using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Abstractions.Rest;
 using Remora.Discord.Caching.Services;
+using Remora.Rest;
 using Remora.Results;
 
 namespace Remora.Discord.Caching.API;
@@ -34,7 +35,7 @@ namespace Remora.Discord.Caching.API;
 /// Decorates the registered OAuth2 API with caching functionality.
 /// </summary>
 [PublicAPI]
-public class CachingDiscordRestOAuth2API : IDiscordRestOAuth2API
+public partial class CachingDiscordRestOAuth2API : IDiscordRestOAuth2API, IRestCustomizable
 {
     private readonly IDiscordRestOAuth2API _actual;
     private readonly CacheService _cacheService;

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestTemplateAPI.Delegations.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestTemplateAPI.Delegations.cs
@@ -1,5 +1,5 @@
 //
-//  CachingDiscordRestInteractionAPI.Delegations.cs
+//  CachingDiscordRestTemplateAPI.Delegations.cs
 //
 //  Author:
 //       Jarl Gullberg <jarl.gullberg@gmail.com>
@@ -21,33 +21,12 @@
 //
 
 using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using OneOf;
-using Remora.Discord.API.Abstractions.Objects;
-using Remora.Discord.API.Abstractions.Rest;
 using Remora.Rest;
-using Remora.Rest.Core;
-using Remora.Results;
 
 namespace Remora.Discord.Caching.API;
 
-public partial class CachingDiscordRestInteractionAPI
+public partial class CachingDiscordRestTemplateAPI
 {
-    /// <inheritdoc />
-    public Task<Result> CreateInteractionResponseAsync
-    (
-        Snowflake interactionID,
-        string interactionToken,
-        IInteractionResponse response,
-        Optional<IReadOnlyList<OneOf<FileData, IPartialAttachment>>> attachments = default,
-        CancellationToken ct = default
-    )
-    {
-        return _actual.CreateInteractionResponseAsync(interactionID, interactionToken, response, attachments, ct);
-    }
-
     /// <inheritdoc/>
     public RestRequestCustomization WithCustomization(Action<RestRequestBuilder> requestCustomizer)
     {

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestTemplateAPI.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestTemplateAPI.cs
@@ -22,15 +22,12 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
-using Remora.Discord.Caching.Abstractions.Services;
+using Remora.Discord.API.Abstractions.Rest;
 using Remora.Discord.Caching.Services;
-using Remora.Discord.Rest.API;
-using Remora.Rest;
 using Remora.Rest.Core;
 using Remora.Results;
 
@@ -38,25 +35,28 @@ namespace Remora.Discord.Caching.API;
 
 /// <inheritdoc />
 [PublicAPI]
-public class CachingDiscordRestTemplateAPI : DiscordRestTemplateAPI
+public class CachingDiscordRestTemplateAPI : IDiscordRestTemplateAPI
 {
+    private readonly IDiscordRestTemplateAPI _actual;
     private readonly CacheService _cacheService;
 
-    /// <inheritdoc cref="DiscordRestTemplateAPI(IRestHttpClient, JsonSerializerOptions, ICacheProvider)" />
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CachingDiscordRestTemplateAPI"/> class.
+    /// </summary>
+    /// <param name="actual">The decorated instance.</param>
+    /// <param name="cacheService">The cache service.</param>
     public CachingDiscordRestTemplateAPI
     (
-        IRestHttpClient restHttpClient,
-        JsonSerializerOptions jsonOptions,
-        ICacheProvider rateLimitCache,
+        IDiscordRestTemplateAPI actual,
         CacheService cacheService
     )
-        : base(restHttpClient, jsonOptions, rateLimitCache)
     {
+        _actual = actual;
         _cacheService = cacheService;
     }
 
     /// <inheritdoc />
-    public override async Task<Result<ITemplate>> GetTemplateAsync
+    public async Task<Result<ITemplate>> GetTemplateAsync
     (
         string templateCode,
         CancellationToken ct = default
@@ -70,7 +70,7 @@ public class CachingDiscordRestTemplateAPI : DiscordRestTemplateAPI
             return Result<ITemplate>.FromSuccess(cacheResult.Entity);
         }
 
-        var getTemplate = await base.GetTemplateAsync(templateCode, ct);
+        var getTemplate = await _actual.GetTemplateAsync(templateCode, ct);
         if (!getTemplate.IsSuccess)
         {
             return getTemplate;
@@ -83,7 +83,7 @@ public class CachingDiscordRestTemplateAPI : DiscordRestTemplateAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<ITemplate>> CreateGuildTemplateAsync
+    public async Task<Result<ITemplate>> CreateGuildTemplateAsync
     (
         Snowflake guildID,
         string name,
@@ -91,7 +91,7 @@ public class CachingDiscordRestTemplateAPI : DiscordRestTemplateAPI
         CancellationToken ct = default
     )
     {
-        var createTemplate = await base.CreateGuildTemplateAsync(guildID, name, description, ct);
+        var createTemplate = await _actual.CreateGuildTemplateAsync(guildID, name, description, ct);
         if (!createTemplate.IsSuccess)
         {
             return createTemplate;
@@ -106,14 +106,14 @@ public class CachingDiscordRestTemplateAPI : DiscordRestTemplateAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<ITemplate>> DeleteGuildTemplateAsync
+    public async Task<Result<ITemplate>> DeleteGuildTemplateAsync
     (
         Snowflake guildID,
         string templateCode,
         CancellationToken ct = default
     )
     {
-        var deleteTemplate = await base.DeleteGuildTemplateAsync(guildID, templateCode, ct);
+        var deleteTemplate = await _actual.DeleteGuildTemplateAsync(guildID, templateCode, ct);
         if (!deleteTemplate.IsSuccess)
         {
             return deleteTemplate;
@@ -126,7 +126,7 @@ public class CachingDiscordRestTemplateAPI : DiscordRestTemplateAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IReadOnlyList<ITemplate>>> GetGuildTemplatesAsync
+    public async Task<Result<IReadOnlyList<ITemplate>>> GetGuildTemplatesAsync
     (
         Snowflake guildID,
         CancellationToken ct = default
@@ -140,7 +140,7 @@ public class CachingDiscordRestTemplateAPI : DiscordRestTemplateAPI
             return Result<IReadOnlyList<ITemplate>>.FromSuccess(cacheResult.Entity);
         }
 
-        var getTemplates = await base.GetGuildTemplatesAsync(guildID, ct);
+        var getTemplates = await _actual.GetGuildTemplatesAsync(guildID, ct);
         if (!getTemplates.IsSuccess)
         {
             return getTemplates;
@@ -159,7 +159,7 @@ public class CachingDiscordRestTemplateAPI : DiscordRestTemplateAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<ITemplate>> ModifyGuildTemplateAsync
+    public async Task<Result<ITemplate>> ModifyGuildTemplateAsync
     (
         Snowflake guildID,
         string templateCode,
@@ -168,7 +168,7 @@ public class CachingDiscordRestTemplateAPI : DiscordRestTemplateAPI
         CancellationToken ct = default
     )
     {
-        var modifyTemplate = await base.ModifyGuildTemplateAsync(guildID, templateCode, name, description, ct);
+        var modifyTemplate = await _actual.ModifyGuildTemplateAsync(guildID, templateCode, name, description, ct);
         if (!modifyTemplate.IsSuccess)
         {
             return modifyTemplate;
@@ -183,14 +183,14 @@ public class CachingDiscordRestTemplateAPI : DiscordRestTemplateAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<ITemplate>> SyncGuildTemplateAsync
+    public async Task<Result<ITemplate>> SyncGuildTemplateAsync
     (
         Snowflake guildID,
         string templateCode,
         CancellationToken ct = default
     )
     {
-        var syncTemplate = await base.SyncGuildTemplateAsync(guildID, templateCode, ct);
+        var syncTemplate = await _actual.SyncGuildTemplateAsync(guildID, templateCode, ct);
         if (!syncTemplate.IsSuccess)
         {
             return syncTemplate;
@@ -205,7 +205,7 @@ public class CachingDiscordRestTemplateAPI : DiscordRestTemplateAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IGuild>> CreateGuildFromTemplateAsync
+    public async Task<Result<IGuild>> CreateGuildFromTemplateAsync
     (
         string templateCode,
         string name,
@@ -213,7 +213,7 @@ public class CachingDiscordRestTemplateAPI : DiscordRestTemplateAPI
         CancellationToken ct = default
     )
     {
-        var createGuild = await base.CreateGuildFromTemplateAsync(templateCode, name, icon, ct);
+        var createGuild = await _actual.CreateGuildFromTemplateAsync(templateCode, name, icon, ct);
         if (!createGuild.IsSuccess)
         {
             return createGuild;

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestTemplateAPI.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestTemplateAPI.cs
@@ -28,6 +28,7 @@ using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Abstractions.Rest;
 using Remora.Discord.Caching.Services;
+using Remora.Rest;
 using Remora.Rest.Core;
 using Remora.Results;
 
@@ -35,7 +36,7 @@ namespace Remora.Discord.Caching.API;
 
 /// <inheritdoc />
 [PublicAPI]
-public class CachingDiscordRestTemplateAPI : IDiscordRestTemplateAPI
+public partial class CachingDiscordRestTemplateAPI : IDiscordRestTemplateAPI, IRestCustomizable
 {
     private readonly IDiscordRestTemplateAPI _actual;
     private readonly CacheService _cacheService;

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestUserAPI.Delegations.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestUserAPI.Delegations.cs
@@ -20,10 +20,12 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Remora.Discord.API.Abstractions.Objects;
+using Remora.Rest;
 using Remora.Rest.Core;
 using Remora.Results;
 
@@ -47,5 +49,28 @@ public partial class CachingDiscordRestUserAPI
     public Task<Result> LeaveGuildAsync(Snowflake guildID, CancellationToken ct = default)
     {
         return _actual.LeaveGuildAsync(guildID, ct);
+    }
+
+    /// <inheritdoc/>
+    public RestRequestCustomization WithCustomization(Action<RestRequestBuilder> requestCustomizer)
+    {
+        if (_actual is not IRestCustomizable customizable)
+        {
+            // TODO: not ideal...
+            throw new NotImplementedException("The decorated API type is not customizable.");
+        }
+
+        return customizable.WithCustomization(requestCustomizer);
+    }
+
+    /// <inheritdoc/>
+    void IRestCustomizable.RemoveCustomization(RestRequestCustomization customization)
+    {
+        if (_actual is not IRestCustomizable customizable)
+        {
+            return;
+        }
+
+        customizable.RemoveCustomization(customization);
     }
 }

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestUserAPI.Delegations.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestUserAPI.Delegations.cs
@@ -1,0 +1,51 @@
+//
+//  CachingDiscordRestUserAPI.Delegations.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Rest.Core;
+using Remora.Results;
+
+namespace Remora.Discord.Caching.API;
+
+public partial class CachingDiscordRestUserAPI
+{
+    /// <inheritdoc />
+    public Task<Result<IReadOnlyList<IPartialGuild>>> GetCurrentUserGuildsAsync
+    (
+        Optional<Snowflake> before = default,
+        Optional<Snowflake> after = default,
+        Optional<int> limit = default,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.GetCurrentUserGuildsAsync(before, after, limit, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<Result> LeaveGuildAsync(Snowflake guildID, CancellationToken ct = default)
+    {
+        return _actual.LeaveGuildAsync(guildID, ct);
+    }
+}

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestUserAPI.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestUserAPI.cs
@@ -28,6 +28,7 @@ using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Abstractions.Rest;
 using Remora.Discord.Caching.Services;
+using Remora.Rest;
 using Remora.Rest.Core;
 using Remora.Results;
 
@@ -37,7 +38,7 @@ namespace Remora.Discord.Caching.API;
 /// Decorates the registered user API with caching functionality.
 /// </summary>
 [PublicAPI]
-public partial class CachingDiscordRestUserAPI : IDiscordRestUserAPI
+public partial class CachingDiscordRestUserAPI : IDiscordRestUserAPI, IRestCustomizable
 {
     private readonly IDiscordRestUserAPI _actual;
     private readonly CacheService _cacheService;

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestVoiceAPI.Delegations.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestVoiceAPI.Delegations.cs
@@ -1,5 +1,5 @@
 //
-//  CachingDiscordRestInteractionAPI.Delegations.cs
+//  CachingDiscordRestVoiceAPI.Delegations.cs
 //
 //  Author:
 //       Jarl Gullberg <jarl.gullberg@gmail.com>
@@ -21,33 +21,12 @@
 //
 
 using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using OneOf;
-using Remora.Discord.API.Abstractions.Objects;
-using Remora.Discord.API.Abstractions.Rest;
 using Remora.Rest;
-using Remora.Rest.Core;
-using Remora.Results;
 
 namespace Remora.Discord.Caching.API;
 
-public partial class CachingDiscordRestInteractionAPI
+public partial class CachingDiscordRestVoiceAPI
 {
-    /// <inheritdoc />
-    public Task<Result> CreateInteractionResponseAsync
-    (
-        Snowflake interactionID,
-        string interactionToken,
-        IInteractionResponse response,
-        Optional<IReadOnlyList<OneOf<FileData, IPartialAttachment>>> attachments = default,
-        CancellationToken ct = default
-    )
-    {
-        return _actual.CreateInteractionResponseAsync(interactionID, interactionToken, response, attachments, ct);
-    }
-
     /// <inheritdoc/>
     public RestRequestCustomization WithCustomization(Action<RestRequestBuilder> requestCustomizer)
     {

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestVoiceAPI.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestVoiceAPI.cs
@@ -27,6 +27,7 @@ using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Abstractions.Rest;
 using Remora.Discord.Caching.Services;
+using Remora.Rest;
 using Remora.Results;
 
 namespace Remora.Discord.Caching.API;
@@ -35,7 +36,7 @@ namespace Remora.Discord.Caching.API;
 /// Decorates the registered voice API with caching functionality.
 /// </summary>
 [PublicAPI]
-public class CachingDiscordRestVoiceAPI : IDiscordRestVoiceAPI
+public partial class CachingDiscordRestVoiceAPI : IDiscordRestVoiceAPI, IRestCustomizable
 {
     private readonly IDiscordRestVoiceAPI _actual;
     private readonly CacheService _cacheService;

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestVoiceAPI.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestVoiceAPI.cs
@@ -21,40 +21,42 @@
 //
 
 using System.Collections.Generic;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
-using Remora.Discord.Caching.Abstractions.Services;
+using Remora.Discord.API.Abstractions.Rest;
 using Remora.Discord.Caching.Services;
-using Remora.Discord.Rest.API;
-using Remora.Rest;
 using Remora.Results;
 
 namespace Remora.Discord.Caching.API;
 
-/// <inheritdoc />
+/// <summary>
+/// Decorates the registered voice API with caching functionality.
+/// </summary>
 [PublicAPI]
-public class CachingDiscordRestVoiceAPI : DiscordRestVoiceAPI
+public class CachingDiscordRestVoiceAPI : IDiscordRestVoiceAPI
 {
+    private readonly IDiscordRestVoiceAPI _actual;
     private readonly CacheService _cacheService;
 
-    /// <inheritdoc cref="DiscordRestVoiceAPI(IRestHttpClient, JsonSerializerOptions, ICacheProvider)" />
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CachingDiscordRestVoiceAPI"/> class.
+    /// </summary>
+    /// <param name="actual">The decorated instance.</param>
+    /// <param name="cacheService">The cache service.</param>
     public CachingDiscordRestVoiceAPI
     (
-        IRestHttpClient restHttpClient,
-        JsonSerializerOptions jsonOptions,
-        ICacheProvider rateLimitCache,
+        IDiscordRestVoiceAPI actual,
         CacheService cacheService
     )
-        : base(restHttpClient, jsonOptions, rateLimitCache)
     {
+        _actual = actual;
         _cacheService = cacheService;
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IReadOnlyList<IVoiceRegion>>> ListVoiceRegionsAsync
+    public async Task<Result<IReadOnlyList<IVoiceRegion>>> ListVoiceRegionsAsync
     (
         CancellationToken ct = default
     )
@@ -67,7 +69,7 @@ public class CachingDiscordRestVoiceAPI : DiscordRestVoiceAPI
             return Result<IReadOnlyList<IVoiceRegion>>.FromSuccess(cacheResult.Entity);
         }
 
-        var listRegions = await base.ListVoiceRegionsAsync(ct);
+        var listRegions = await _actual.ListVoiceRegionsAsync(ct);
         if (!listRegions.IsSuccess)
         {
             return listRegions;

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestWebhookAPI.Delegations.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestWebhookAPI.Delegations.cs
@@ -1,5 +1,5 @@
 //
-//  CachingDiscordRestInteractionAPI.Delegations.cs
+//  CachingDiscordRestWebhookAPI.Delegations.cs
 //
 //  Author:
 //       Jarl Gullberg <jarl.gullberg@gmail.com>
@@ -21,33 +21,12 @@
 //
 
 using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using OneOf;
-using Remora.Discord.API.Abstractions.Objects;
-using Remora.Discord.API.Abstractions.Rest;
 using Remora.Rest;
-using Remora.Rest.Core;
-using Remora.Results;
 
 namespace Remora.Discord.Caching.API;
 
-public partial class CachingDiscordRestInteractionAPI
+public partial class CachingDiscordRestWebhookAPI
 {
-    /// <inheritdoc />
-    public Task<Result> CreateInteractionResponseAsync
-    (
-        Snowflake interactionID,
-        string interactionToken,
-        IInteractionResponse response,
-        Optional<IReadOnlyList<OneOf<FileData, IPartialAttachment>>> attachments = default,
-        CancellationToken ct = default
-    )
-    {
-        return _actual.CreateInteractionResponseAsync(interactionID, interactionToken, response, attachments, ct);
-    }
-
     /// <inheritdoc/>
     public RestRequestCustomization WithCustomization(Action<RestRequestBuilder> requestCustomizer)
     {

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestWebhookAPI.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestWebhookAPI.cs
@@ -29,6 +29,7 @@ using OneOf;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Abstractions.Rest;
 using Remora.Discord.Caching.Services;
+using Remora.Rest;
 using Remora.Rest.Core;
 using Remora.Results;
 
@@ -38,7 +39,7 @@ namespace Remora.Discord.Caching.API;
 /// Decorates the registered webhook API with caching functionality.
 /// </summary>
 [PublicAPI]
-public class CachingDiscordRestWebhookAPI : IDiscordRestWebhookAPI
+public partial class CachingDiscordRestWebhookAPI : IDiscordRestWebhookAPI, IRestCustomizable
 {
     private readonly IDiscordRestWebhookAPI _actual;
     private readonly CacheService _cacheService;

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestWebhookAPI.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestWebhookAPI.cs
@@ -22,43 +22,44 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using OneOf;
 using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Abstractions.Rest;
-using Remora.Discord.Caching.Abstractions.Services;
 using Remora.Discord.Caching.Services;
-using Remora.Discord.Rest.API;
-using Remora.Rest;
 using Remora.Rest.Core;
 using Remora.Results;
 
 namespace Remora.Discord.Caching.API;
 
-/// <inheritdoc />
+/// <summary>
+/// Decorates the registered webhook API with caching functionality.
+/// </summary>
 [PublicAPI]
-public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
+public class CachingDiscordRestWebhookAPI : IDiscordRestWebhookAPI
 {
+    private readonly IDiscordRestWebhookAPI _actual;
     private readonly CacheService _cacheService;
 
-    /// <inheritdoc cref="DiscordRestWebhookAPI(IRestHttpClient, JsonSerializerOptions, ICacheProvider)" />
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CachingDiscordRestWebhookAPI"/> class.
+    /// </summary>
+    /// <param name="actual">The decorated instance.</param>
+    /// <param name="cacheService">The cache service.</param>
     public CachingDiscordRestWebhookAPI
     (
-        IRestHttpClient restHttpClient,
-        JsonSerializerOptions jsonOptions,
-        ICacheProvider rateLimitCache,
+        IDiscordRestWebhookAPI actual,
         CacheService cacheService
     )
-        : base(restHttpClient, jsonOptions, rateLimitCache)
     {
+        _actual = actual;
         _cacheService = cacheService;
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IWebhook>> CreateWebhookAsync
+    public async Task<Result<IWebhook>> CreateWebhookAsync
     (
         Snowflake channelID,
         string name,
@@ -67,7 +68,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
         CancellationToken ct = default
     )
     {
-        var createWebhook = await base.CreateWebhookAsync(channelID, name, avatar, reason, ct);
+        var createWebhook = await _actual.CreateWebhookAsync(channelID, name, avatar, reason, ct);
         if (!createWebhook.IsSuccess)
         {
             return createWebhook;
@@ -82,14 +83,14 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result> DeleteWebhookAsync
+    public async Task<Result> DeleteWebhookAsync
     (
         Snowflake webhookID,
         Optional<string> reason = default,
         CancellationToken ct = default
     )
     {
-        var deleteWebhook = await base.DeleteWebhookAsync(webhookID, reason, ct);
+        var deleteWebhook = await _actual.DeleteWebhookAsync(webhookID, reason, ct);
         if (!deleteWebhook.IsSuccess)
         {
             return deleteWebhook;
@@ -102,7 +103,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IMessage?>> ExecuteWebhookAsync
+    public async Task<Result<IMessage?>> ExecuteWebhookAsync
     (
         Snowflake webhookID,
         string token,
@@ -120,7 +121,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
         CancellationToken ct = default
     )
     {
-        var execute = await base.ExecuteWebhookAsync
+        var execute = await _actual.ExecuteWebhookAsync
         (
             webhookID,
             token,
@@ -156,7 +157,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IWebhook>> GetWebhookAsync
+    public async Task<Result<IWebhook>> GetWebhookAsync
     (
         Snowflake webhookID,
         CancellationToken ct = default
@@ -170,7 +171,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
             return Result<IWebhook>.FromSuccess(cacheResult.Entity);
         }
 
-        var getWebhook = await base.GetWebhookAsync(webhookID, ct);
+        var getWebhook = await _actual.GetWebhookAsync(webhookID, ct);
         if (!getWebhook.IsSuccess)
         {
             return getWebhook;
@@ -183,7 +184,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IWebhook>> ModifyWebhookAsync
+    public async Task<Result<IWebhook>> ModifyWebhookAsync
     (
         Snowflake webhookID,
         Optional<string> name = default,
@@ -193,7 +194,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
         CancellationToken ct = default
     )
     {
-        var modifyWebhook = await base.ModifyWebhookAsync(webhookID, name, avatar, channelID, reason, ct);
+        var modifyWebhook = await _actual.ModifyWebhookAsync(webhookID, name, avatar, channelID, reason, ct);
         if (!modifyWebhook.IsSuccess)
         {
             return modifyWebhook;
@@ -208,7 +209,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IReadOnlyList<IWebhook>>> GetChannelWebhooksAsync
+    public async Task<Result<IReadOnlyList<IWebhook>>> GetChannelWebhooksAsync
     (
         Snowflake channelID,
         CancellationToken ct = default
@@ -222,7 +223,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
             return Result<IReadOnlyList<IWebhook>>.FromSuccess(cacheResult.Entity);
         }
 
-        var getWebhooks = await base.GetChannelWebhooksAsync(channelID, ct);
+        var getWebhooks = await _actual.GetChannelWebhooksAsync(channelID, ct);
         if (!getWebhooks.IsSuccess)
         {
             return getWebhooks;
@@ -241,7 +242,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IReadOnlyList<IWebhook>>> GetGuildWebhooksAsync
+    public async Task<Result<IReadOnlyList<IWebhook>>> GetGuildWebhooksAsync
     (
         Snowflake guildID, CancellationToken ct = default
     )
@@ -254,7 +255,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
             return Result<IReadOnlyList<IWebhook>>.FromSuccess(cacheResult.Entity);
         }
 
-        var getWebhooks = await base.GetGuildWebhooksAsync(guildID, ct);
+        var getWebhooks = await _actual.GetGuildWebhooksAsync(guildID, ct);
         if (!getWebhooks.IsSuccess)
         {
             return getWebhooks;
@@ -273,7 +274,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result> DeleteWebhookWithTokenAsync
+    public async Task<Result> DeleteWebhookWithTokenAsync
     (
         Snowflake webhookID,
         string token,
@@ -281,7 +282,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
         CancellationToken ct = default
     )
     {
-        var deleteWebhook = await base.DeleteWebhookWithTokenAsync(webhookID, token, reason, ct);
+        var deleteWebhook = await _actual.DeleteWebhookWithTokenAsync(webhookID, token, reason, ct);
         if (!deleteWebhook.IsSuccess)
         {
             return deleteWebhook;
@@ -294,7 +295,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IWebhook>> GetWebhookWithTokenAsync
+    public async Task<Result<IWebhook>> GetWebhookWithTokenAsync
     (
         Snowflake webhookID,
         string token,
@@ -309,7 +310,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
             return Result<IWebhook>.FromSuccess(cacheResult.Entity);
         }
 
-        var getWebhook = await base.GetWebhookWithTokenAsync(webhookID, token, ct);
+        var getWebhook = await _actual.GetWebhookWithTokenAsync(webhookID, token, ct);
         if (!getWebhook.IsSuccess)
         {
             return getWebhook;
@@ -322,7 +323,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IWebhook>> ModifyWebhookWithTokenAsync
+    public async Task<Result<IWebhook>> ModifyWebhookWithTokenAsync
     (
         Snowflake webhookID,
         string token,
@@ -332,7 +333,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
         CancellationToken ct = default
     )
     {
-        var modifyWebhook = await base.ModifyWebhookWithTokenAsync(webhookID, token, name, avatar, reason, ct);
+        var modifyWebhook = await _actual.ModifyWebhookWithTokenAsync(webhookID, token, name, avatar, reason, ct);
         if (!modifyWebhook.IsSuccess)
         {
             return modifyWebhook;
@@ -347,7 +348,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IMessage>> EditWebhookMessageAsync
+    public async Task<Result<IMessage>> EditWebhookMessageAsync
     (
         Snowflake webhookID,
         string token,
@@ -361,7 +362,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
         CancellationToken ct = default
     )
     {
-        var result = await base.EditWebhookMessageAsync
+        var result = await _actual.EditWebhookMessageAsync
         (
             webhookID,
             token,
@@ -387,7 +388,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result> DeleteWebhookMessageAsync
+    public async Task<Result> DeleteWebhookMessageAsync
     (
         Snowflake webhookID,
         string token,
@@ -396,7 +397,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
         CancellationToken ct = default
     )
     {
-        var result = await base.DeleteWebhookMessageAsync(webhookID, token, messageID, threadID, ct);
+        var result = await _actual.DeleteWebhookMessageAsync(webhookID, token, messageID, threadID, ct);
         if (!result.IsSuccess)
         {
             return result;
@@ -409,7 +410,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
     }
 
     /// <inheritdoc />
-    public override async Task<Result<IMessage>> GetWebhookMessageAsync
+    public async Task<Result<IMessage>> GetWebhookMessageAsync
     (
         Snowflake webhookID,
         string webhookToken,
@@ -426,7 +427,7 @@ public class CachingDiscordRestWebhookAPI : DiscordRestWebhookAPI
             return Result<IMessage>.FromSuccess(cacheResult.Entity);
         }
 
-        var result = await base.GetWebhookMessageAsync(webhookID, webhookToken, messageID, threadID, ct);
+        var result = await _actual.GetWebhookMessageAsync(webhookID, webhookToken, messageID, threadID, ct);
         if (!result.IsSuccess)
         {
             return result;

--- a/Backend/Remora.Discord.Caching/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/Remora.Discord.Caching/Extensions/ServiceCollectionExtensions.cs
@@ -20,20 +20,18 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-using System.Text.Json;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Remora.Discord.API.Abstractions.Rest;
-using Remora.Discord.Caching.Abstractions.Services;
 using Remora.Discord.Caching.API;
 using Remora.Discord.Caching.Responders;
 using Remora.Discord.Caching.Services;
 using Remora.Discord.Gateway.Extensions;
 using Remora.Discord.Gateway.Responders;
-using Remora.Rest;
+using Remora.Discord.Rest.Extensions;
 
 namespace Remora.Discord.Caching.Extensions;
 
@@ -61,76 +59,16 @@ public static class ServiceCollectionExtensions
         services.AddOptions<CacheSettings>();
 
         services
-            .Replace(ServiceDescriptor.Transient<IDiscordRestChannelAPI>(s => new CachingDiscordRestChannelAPI
-            (
-                s.GetRequiredService<IRestHttpClient>(),
-                s.GetRequiredService<IOptionsMonitor<JsonSerializerOptions>>().Get("Discord"),
-                s.GetRequiredService<ICacheProvider>(),
-                s.GetRequiredService<CacheService>()
-            )))
-            .Replace(ServiceDescriptor.Transient<IDiscordRestEmojiAPI>(s => new CachingDiscordRestEmojiAPI
-            (
-                s.GetRequiredService<IRestHttpClient>(),
-                s.GetRequiredService<IOptionsMonitor<JsonSerializerOptions>>().Get("Discord"),
-                s.GetRequiredService<ICacheProvider>(),
-                s.GetRequiredService<CacheService>()
-            )))
-            .Replace(ServiceDescriptor.Transient<IDiscordRestGuildAPI>(s => new CachingDiscordRestGuildAPI
-            (
-                s.GetRequiredService<IRestHttpClient>(),
-                s.GetRequiredService<IOptionsMonitor<JsonSerializerOptions>>().Get("Discord"),
-                s.GetRequiredService<ICacheProvider>(),
-                s.GetRequiredService<CacheService>()
-            )))
-            .Replace(ServiceDescriptor.Transient<IDiscordRestInteractionAPI>(s => new CachingDiscordRestInteractionAPI
-            (
-                s.GetRequiredService<IRestHttpClient>(),
-                s.GetRequiredService<IOptionsMonitor<JsonSerializerOptions>>().Get("Discord"),
-                s.GetRequiredService<ICacheProvider>(),
-                s.GetRequiredService<CacheService>()
-            )))
-            .Replace(ServiceDescriptor.Transient<IDiscordRestInviteAPI>(s => new CachingDiscordRestInviteAPI
-            (
-                s.GetRequiredService<IRestHttpClient>(),
-                s.GetRequiredService<IOptionsMonitor<JsonSerializerOptions>>().Get("Discord"),
-                s.GetRequiredService<ICacheProvider>(),
-                s.GetRequiredService<CacheService>()
-            )))
-            .Replace(ServiceDescriptor.Transient<IDiscordRestOAuth2API>(s => new CachingDiscordRestOAuth2API
-            (
-                s.GetRequiredService<IRestHttpClient>(),
-                s.GetRequiredService<IOptionsMonitor<JsonSerializerOptions>>().Get("Discord"),
-                s.GetRequiredService<ICacheProvider>(),
-                s.GetRequiredService<CacheService>()
-            )))
-            .Replace(ServiceDescriptor.Transient<IDiscordRestTemplateAPI>(s => new CachingDiscordRestTemplateAPI
-            (
-                s.GetRequiredService<IRestHttpClient>(),
-                s.GetRequiredService<IOptionsMonitor<JsonSerializerOptions>>().Get("Discord"),
-                s.GetRequiredService<ICacheProvider>(),
-                s.GetRequiredService<CacheService>()
-            )))
-            .Replace(ServiceDescriptor.Transient<IDiscordRestUserAPI>(s => new CachingDiscordRestUserAPI
-            (
-                s.GetRequiredService<IRestHttpClient>(),
-                s.GetRequiredService<IOptionsMonitor<JsonSerializerOptions>>().Get("Discord"),
-                s.GetRequiredService<ICacheProvider>(),
-                s.GetRequiredService<CacheService>()
-            )))
-            .Replace(ServiceDescriptor.Transient<IDiscordRestVoiceAPI>(s => new CachingDiscordRestVoiceAPI
-            (
-                s.GetRequiredService<IRestHttpClient>(),
-                s.GetRequiredService<IOptionsMonitor<JsonSerializerOptions>>().Get("Discord"),
-                s.GetRequiredService<ICacheProvider>(),
-                s.GetRequiredService<CacheService>()
-            )))
-            .Replace(ServiceDescriptor.Transient<IDiscordRestWebhookAPI>(s => new CachingDiscordRestWebhookAPI
-            (
-                s.GetRequiredService<IRestHttpClient>(),
-                s.GetRequiredService<IOptionsMonitor<JsonSerializerOptions>>().Get("Discord"),
-                s.GetRequiredService<ICacheProvider>(),
-                s.GetRequiredService<CacheService>()
-            )));
+            .Decorate<IDiscordRestChannelAPI, CachingDiscordRestChannelAPI>()
+            .Decorate<IDiscordRestEmojiAPI, CachingDiscordRestEmojiAPI>()
+            .Decorate<IDiscordRestGuildAPI, CachingDiscordRestGuildAPI>()
+            .Decorate<IDiscordRestInteractionAPI, CachingDiscordRestInteractionAPI>()
+            .Decorate<IDiscordRestInviteAPI, CachingDiscordRestInviteAPI>()
+            .Decorate<IDiscordRestOAuth2API, CachingDiscordRestOAuth2API>()
+            .Decorate<IDiscordRestTemplateAPI, CachingDiscordRestTemplateAPI>()
+            .Decorate<IDiscordRestUserAPI, CachingDiscordRestUserAPI>()
+            .Decorate<IDiscordRestVoiceAPI, CachingDiscordRestVoiceAPI>()
+            .Decorate<IDiscordRestWebhookAPI, CachingDiscordRestWebhookAPI>();
 
         services
             .AddResponder<EarlyCacheResponder>(ResponderGroup.Early)

--- a/Backend/Remora.Discord.Caching/Remora.Discord.Caching.csproj
+++ b/Backend/Remora.Discord.Caching/Remora.Discord.Caching.csproj
@@ -17,4 +17,19 @@
       <ProjectReference Include="..\Remora.Discord.Gateway\Remora.Discord.Gateway.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Compile Update="API\CachingDiscordRestChannelAPI.Delegations.cs">
+        <DependentUpon>CachingDiscordRestChannelAPI.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\CachingDiscordRestGuildAPI.Delegations.cs">
+        <DependentUpon>CachingDiscordRestGuildAPI.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\CachingDiscordRestInteractionAPI.Delegations.cs">
+        <DependentUpon>CachingDiscordRestInteractionAPI.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\CachingDiscordRestUserAPI.Delegations.cs">
+        <DependentUpon>CachingDiscordRestUserAPI.cs</DependentUpon>
+      </Compile>
+    </ItemGroup>
+
 </Project>

--- a/Backend/Remora.Discord.Caching/Remora.Discord.Caching.csproj
+++ b/Backend/Remora.Discord.Caching/Remora.Discord.Caching.csproj
@@ -30,6 +30,24 @@
       <Compile Update="API\CachingDiscordRestUserAPI.Delegations.cs">
         <DependentUpon>CachingDiscordRestUserAPI.cs</DependentUpon>
       </Compile>
+      <Compile Update="API\CachingDiscordRestEmojiAPI.Delegations.cs">
+        <DependentUpon>CachingDiscordRestEmojiAPI.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\CachingDiscordRestInviteAPI.Delegations.cs">
+        <DependentUpon>CachingDiscordRestInviteAPI.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\CachingDiscordRestOAuth2API.Delegations.cs">
+        <DependentUpon>CachingDiscordRestOAuth2API.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\CachingDiscordRestTemplateAPI.Delegations.cs">
+        <DependentUpon>CachingDiscordRestTemplateAPI.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\CachingDiscordRestVoiceAPI.Delegations.cs">
+        <DependentUpon>CachingDiscordRestVoiceAPI.cs</DependentUpon>
+      </Compile>
+      <Compile Update="API\CachingDiscordRestWebhookAPI.Delegations.cs">
+        <DependentUpon>CachingDiscordRestWebhookAPI.cs</DependentUpon>
+      </Compile>
     </ItemGroup>
 
 </Project>

--- a/Backend/Remora.Discord.Rest/API/AbstractDiscordRestAPI.cs
+++ b/Backend/Remora.Discord.Rest/API/AbstractDiscordRestAPI.cs
@@ -32,7 +32,7 @@ namespace Remora.Discord.Rest.API;
 /// Acts as an abstract base for REST API instances.
 /// </summary>
 [PublicAPI]
-public abstract class AbstractDiscordRestAPI
+public abstract class AbstractDiscordRestAPI : IRestCustomizable
 {
     /// <summary>
     /// Gets the <see cref="RestHttpClient{TError}"/> available to the API instance.
@@ -71,5 +71,11 @@ public abstract class AbstractDiscordRestAPI
     public RestRequestCustomization WithCustomization(Action<RestRequestBuilder> requestCustomizer)
     {
         return this.RestHttpClient.WithCustomization(requestCustomizer);
+    }
+
+    /// <inheritdoc cref="RestHttpClient{TError}.WithCustomization"/>
+    void IRestCustomizable.RemoveCustomization(RestRequestCustomization customization)
+    {
+        this.RestHttpClient.RemoveCustomization(customization);
     }
 }

--- a/Backend/Remora.Discord.Rest/API/Applications/DiscordRestApplicationAPI.cs
+++ b/Backend/Remora.Discord.Rest/API/Applications/DiscordRestApplicationAPI.cs
@@ -21,7 +21,6 @@
 //
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Json;
 using System.Threading;

--- a/Backend/Remora.Discord.Rest/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/Remora.Discord.Rest/Extensions/ServiceCollectionExtensions.cs
@@ -272,8 +272,8 @@ public static class ServiceCollectionExtensions
         (
             typeof(TInterface),
             s => (TInterface)objectFactory(s, new[] { s.CreateInstance(wrappedDescriptor) }),
-            wrappedDescriptor.Lifetime)
-        );
+            wrappedDescriptor.Lifetime
+        ));
 
         return services;
     }

--- a/Remora.Discord.Commands/API/ResponseTrackingInteractionAPI.Delegations.cs
+++ b/Remora.Discord.Commands/API/ResponseTrackingInteractionAPI.Delegations.cs
@@ -1,5 +1,5 @@
 //
-//  CachingDiscordRestInteractionAPI.Delegations.cs
+//  ResponseTrackingInteractionAPI.Delegations.cs
 //
 //  Author:
 //       Jarl Gullberg <jarl.gullberg@gmail.com>
@@ -21,33 +21,12 @@
 //
 
 using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using OneOf;
-using Remora.Discord.API.Abstractions.Objects;
-using Remora.Discord.API.Abstractions.Rest;
 using Remora.Rest;
-using Remora.Rest.Core;
-using Remora.Results;
 
-namespace Remora.Discord.Caching.API;
+namespace Remora.Discord.Commands.API;
 
-public partial class CachingDiscordRestInteractionAPI
+internal partial class ResponseTrackingInteractionAPI
 {
-    /// <inheritdoc />
-    public Task<Result> CreateInteractionResponseAsync
-    (
-        Snowflake interactionID,
-        string interactionToken,
-        IInteractionResponse response,
-        Optional<IReadOnlyList<OneOf<FileData, IPartialAttachment>>> attachments = default,
-        CancellationToken ct = default
-    )
-    {
-        return _actual.CreateInteractionResponseAsync(interactionID, interactionToken, response, attachments, ct);
-    }
-
     /// <inheritdoc/>
     public RestRequestCustomization WithCustomization(Action<RestRequestBuilder> requestCustomizer)
     {

--- a/Remora.Discord.Commands/API/ResponseTrackingInteractionAPI.cs
+++ b/Remora.Discord.Commands/API/ResponseTrackingInteractionAPI.cs
@@ -1,0 +1,212 @@
+//
+//  ResponseTrackingInteractionAPI.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using OneOf;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.API.Abstractions.Rest;
+using Remora.Discord.Commands.Contexts;
+using Remora.Discord.Commands.Services;
+using Remora.Rest.Core;
+using Remora.Results;
+
+namespace Remora.Discord.Commands.API;
+
+/// <summary>
+/// Implements a tracking system for whether an interaction has been responded to.
+/// </summary>
+internal class ResponseTrackingInteractionAPI : IDiscordRestInteractionAPI
+{
+    private readonly ContextInjectionService? _contextInjector;
+    private readonly IDiscordRestInteractionAPI _actual;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResponseTrackingInteractionAPI"/> class.
+    /// </summary>
+    /// <param name="actual">The actual API instance.</param>
+    /// <param name="provider">The service provider.</param>
+    public ResponseTrackingInteractionAPI
+    (
+        IDiscordRestInteractionAPI actual,
+        IServiceProvider provider
+    )
+    {
+        _actual = actual;
+
+        // TODO: Improve this with a proper scope check once I figure out how to do that
+        try
+        {
+            _contextInjector = provider.GetRequiredService<ContextInjectionService>();
+        }
+        catch (InvalidOperationException)
+        {
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Result> CreateInteractionResponseAsync
+    (
+        Snowflake interactionID,
+        string interactionToken,
+        IInteractionResponse response,
+        Optional<IReadOnlyList<OneOf<FileData, IPartialAttachment>>> attachments = default,
+        CancellationToken ct = default
+    )
+    {
+        var createResponse = await _actual.CreateInteractionResponseAsync
+        (
+            interactionID,
+            interactionToken,
+            response,
+            attachments,
+            ct
+        );
+
+        if (_contextInjector?.Context is InteractionContext interactionContext)
+        {
+            // only flip this to true once, and never go back to false
+            interactionContext.HasRespondedToInteraction |= createResponse.IsSuccess;
+        }
+
+        return createResponse;
+    }
+
+    /// <inheritdoc />
+    public Task<Result<IMessage>> GetOriginalInteractionResponseAsync
+    (
+        Snowflake applicationID,
+        string interactionToken,
+        CancellationToken ct = default
+    ) =>
+        _actual.GetOriginalInteractionResponseAsync(applicationID, interactionToken, ct);
+
+    /// <inheritdoc />
+    public Task<Result<IMessage>> EditOriginalInteractionResponseAsync
+    (
+        Snowflake applicationID,
+        string token,
+        Optional<string?> content = default,
+        Optional<IReadOnlyList<IEmbed>?> embeds = default,
+        Optional<IAllowedMentions?> allowedMentions = default,
+        Optional<IReadOnlyList<IMessageComponent>> components = default,
+        Optional<IReadOnlyList<OneOf<FileData, IPartialAttachment>>> attachments = default,
+        CancellationToken ct = default
+    ) =>
+        _actual.EditOriginalInteractionResponseAsync
+        (
+            applicationID,
+            token,
+            content,
+            embeds,
+            allowedMentions,
+            components,
+            attachments,
+            ct
+        );
+
+    /// <inheritdoc />
+    public Task<Result> DeleteOriginalInteractionResponseAsync
+    (
+        Snowflake applicationID,
+        string token,
+        CancellationToken ct = default
+    ) =>
+        _actual.DeleteOriginalInteractionResponseAsync(applicationID, token, ct);
+
+    /// <inheritdoc />
+    public Task<Result<IMessage>> CreateFollowupMessageAsync
+    (
+        Snowflake applicationID,
+        string token,
+        Optional<string> content = default,
+        Optional<bool> isTTS = default,
+        Optional<IReadOnlyList<IEmbed>> embeds = default,
+        Optional<IAllowedMentions> allowedMentions = default,
+        Optional<IReadOnlyList<IMessageComponent>> components = default,
+        Optional<IReadOnlyList<OneOf<FileData, IPartialAttachment>>> attachments = default,
+        Optional<MessageFlags> flags = default,
+        CancellationToken ct = default
+    ) =>
+        _actual.CreateFollowupMessageAsync
+        (
+            applicationID,
+            token,
+            content,
+            isTTS,
+            embeds,
+            allowedMentions,
+            components,
+            attachments,
+            flags,
+            ct
+        );
+
+    /// <inheritdoc />
+    public Task<Result<IMessage>> GetFollowupMessageAsync
+    (
+        Snowflake applicationID,
+        string token,
+        Snowflake messageID,
+        CancellationToken ct = default
+    ) =>
+        _actual.GetFollowupMessageAsync(applicationID, token, messageID, ct);
+
+    /// <inheritdoc />
+    public Task<Result<IMessage>> EditFollowupMessageAsync
+    (
+        Snowflake applicationID,
+        string token,
+        Snowflake messageID,
+        Optional<string?> content = default,
+        Optional<IReadOnlyList<IEmbed>?> embeds = default,
+        Optional<IAllowedMentions?> allowedMentions = default,
+        Optional<IReadOnlyList<IMessageComponent>> components = default,
+        Optional<IReadOnlyList<OneOf<FileData, IPartialAttachment>>> attachments = default,
+        CancellationToken ct = default
+    ) =>
+        _actual.EditFollowupMessageAsync
+        (
+            applicationID,
+            token,
+            messageID,
+            content,
+            embeds,
+            allowedMentions,
+            components,
+            attachments,
+            ct
+        );
+
+    /// <inheritdoc />
+    public Task<Result> DeleteFollowupMessageAsync
+    (
+        Snowflake applicationID,
+        string token,
+        Snowflake messageID,
+        CancellationToken ct = default
+    ) =>
+        _actual.DeleteFollowupMessageAsync(applicationID, token, messageID, ct);
+}

--- a/Remora.Discord.Commands/API/ResponseTrackingInteractionAPI.cs
+++ b/Remora.Discord.Commands/API/ResponseTrackingInteractionAPI.cs
@@ -30,6 +30,7 @@ using Remora.Discord.API.Abstractions.Objects;
 using Remora.Discord.API.Abstractions.Rest;
 using Remora.Discord.Commands.Contexts;
 using Remora.Discord.Commands.Services;
+using Remora.Rest;
 using Remora.Rest.Core;
 using Remora.Results;
 
@@ -38,7 +39,7 @@ namespace Remora.Discord.Commands.API;
 /// <summary>
 /// Implements a tracking system for whether an interaction has been responded to.
 /// </summary>
-internal class ResponseTrackingInteractionAPI : IDiscordRestInteractionAPI
+internal partial class ResponseTrackingInteractionAPI : IDiscordRestInteractionAPI, IRestCustomizable
 {
     private readonly ContextInjectionService? _contextInjector;
     private readonly IDiscordRestInteractionAPI _actual;

--- a/Remora.Discord.Commands/Contexts/InteractionContext.cs
+++ b/Remora.Discord.Commands/Contexts/InteractionContext.cs
@@ -42,4 +42,13 @@ public record InteractionContext
     IInteractionData Data,
     Optional<IMessage> Message,
     Optional<string> Locale
-) : CommandContext(GuildID, ChannelID, User);
+) : CommandContext(GuildID, ChannelID, User)
+{
+    /// <summary>
+    /// Gets a value indicating whether the interaction has been responded to.
+    /// </summary>
+    /// <remarks>
+    /// Note that this value is only updated if the response is created after the context is instantiated.
+    /// </remarks>
+    public bool HasRespondedToInteraction { get; internal set; }
+}

--- a/Remora.Discord.Commands/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Discord.Commands/Extensions/ServiceCollectionExtensions.cs
@@ -22,18 +22,18 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Options;
 using NGettext;
 using Remora.Commands.Extensions;
 using Remora.Commands.Tokenization;
 using Remora.Commands.Trees;
+using Remora.Discord.API.Abstractions.Rest;
+using Remora.Discord.Commands.API;
 using Remora.Discord.Commands.Autocomplete;
 using Remora.Discord.Commands.Conditions;
 using Remora.Discord.Commands.Contexts;
@@ -43,6 +43,7 @@ using Remora.Discord.Commands.Parsers;
 using Remora.Discord.Commands.Responders;
 using Remora.Discord.Commands.Services;
 using Remora.Discord.Gateway.Extensions;
+using Remora.Discord.Rest.Extensions;
 using Remora.Extensions.Options.Immutable;
 
 namespace Remora.Discord.Commands.Extensions;
@@ -127,6 +128,8 @@ public static class ServiceCollectionExtensions
         // Add the helpers used for context injection.
         serviceCollection
             .TryAddScoped<ContextInjectionService>();
+
+        serviceCollection.Decorate<IDiscordRestInteractionAPI, ResponseTrackingInteractionAPI>();
 
         // Set up context injection
         serviceCollection

--- a/Remora.Discord.Commands/Remora.Discord.Commands.csproj
+++ b/Remora.Discord.Commands/Remora.Discord.Commands.csproj
@@ -26,4 +26,10 @@
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Compile Update="API\ResponseTrackingInteractionAPI.Delegations.cs">
+        <DependentUpon>ResponseTrackingInteractionAPI.cs</DependentUpon>
+      </Compile>
+    </ItemGroup>
+
 </Project>

--- a/Tests/Remora.Discord.Commands.Tests/ContextTests.cs
+++ b/Tests/Remora.Discord.Commands.Tests/ContextTests.cs
@@ -31,6 +31,7 @@ using Remora.Discord.Commands.Contexts;
 using Remora.Discord.Commands.Extensions;
 using Remora.Discord.Commands.Services;
 using Remora.Discord.Commands.Tests.Data.Contexts;
+using Remora.Discord.Rest.Extensions;
 using Remora.Discord.Tests;
 using Remora.Rest.Core;
 using Xunit;
@@ -52,6 +53,7 @@ public class ContextTests
     public ContextTests()
     {
         _services = new ServiceCollection()
+            .AddDiscordRest(_ => "dummy")
             .AddDiscordCommands()
             .AddCommandTree()
                 .WithCommandGroup<GroupWithContext>()

--- a/Tests/Remora.Discord.Commands.Tests/TestBases/CommandResponderTestBase.cs
+++ b/Tests/Remora.Discord.Commands.Tests/TestBases/CommandResponderTestBase.cs
@@ -24,6 +24,7 @@ using System;
 using Microsoft.Extensions.DependencyInjection;
 using Remora.Discord.Commands.Extensions;
 using Remora.Discord.Commands.Responders;
+using Remora.Discord.Rest.Extensions;
 
 namespace Remora.Discord.Commands.Tests.TestBases;
 
@@ -45,6 +46,7 @@ public abstract class CommandResponderTestBase : IDisposable
     protected CommandResponderTestBase()
     {
         var serviceCollection = new ServiceCollection()
+            .AddDiscordRest(_ => "dummy")
             .AddDiscordCommands();
 
         // ReSharper disable once VirtualMemberCallInConstructor


### PR DESCRIPTION
This PR implements stateful tracking of whether an interaction has been responded to via the interaction context. This lets the feedback service (among other things) respond appropriately when a contextual message is sent instead of failing outright.

However, this has required some rethinking regarding overriding service registrations (and one ugly hack), which means that a significant overhaul of the caching REST implementations is also part of this PR. Namely, instead of using inheritance and overrides, the services now use the decorator pattern, forwarding calls to a field instead.

This has several benefits, but first and foremost it allows more flexible customization of the REST API types, removing the need to rely on an inheritance chain if behaviour changes or additions are required - any package can now step into the execution path of REST calls and do whatever it needs without interfering with any other implementations that do the same.

It is, however, a rather significant shift in design for these types, so I'd very much appreciate feedback on this PR before I merge it.

EDIT 1:

Based on user feedback, I've also rolled in a reworking of how REST customizations are used, since these changes would make customizations far more unreliable (and incompatible with caching). In short, instead of injecting the concrete type and performing customizations on that, users should now check for the presence of the `IRestCustomizable` interface on the injected interface and operate on that.

```cs
IDiscordRest...API _api;
if (_api is IRestCustomizable customizable)
{
    using var customization = customizable.WithCustomization(b => ...);
}
```

This comes with a caveat, however - if the injected interface does *not* implement `IRestCustomizable`, the decorators will *throw* when you try to add a customization. If you're using Remora's default types, you'll be fine since they all implement this interface, but you may run into issues with external implementations (if any).