### PR TITLE
fix nullability of defaultMemberPermissions param

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestApplicationAPI.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestApplicationAPI.cs
@@ -80,7 +80,7 @@ public interface IDiscordRestApplicationAPI
         Optional<ApplicationCommandType> type = default,
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
-        Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
+        Optional<IDiscordPermissionSet?> defaultMemberPermissions = default,
         Optional<bool?> dmPermission = default,
         CancellationToken ct = default
     );
@@ -136,7 +136,7 @@ public interface IDiscordRestApplicationAPI
         Optional<IReadOnlyList<IApplicationCommandOption>?> options = default,
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
-        Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
+        Optional<IDiscordPermissionSet?> defaultMemberPermissions = default,
         Optional<bool?> dmPermission = default,
         CancellationToken ct = default
     );
@@ -202,7 +202,7 @@ public interface IDiscordRestApplicationAPI
         Optional<ApplicationCommandType> type = default,
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
-        Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
+        Optional<IDiscordPermissionSet?> defaultMemberPermissions = default,
         CancellationToken ct = default
     );
 
@@ -263,7 +263,7 @@ public interface IDiscordRestApplicationAPI
         Optional<IReadOnlyList<IApplicationCommandOption>?> options = default,
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
-        Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
+        Optional<IDiscordPermissionSet?> defaultMemberPermissions = default,
         CancellationToken ct = default
     );
 

--- a/Backend/Remora.Discord.Rest/API/Applications/DiscordRestApplicationAPI.cs
+++ b/Backend/Remora.Discord.Rest/API/Applications/DiscordRestApplicationAPI.cs
@@ -92,7 +92,7 @@ public class DiscordRestApplicationAPI : AbstractDiscordRestAPI, IDiscordRestApp
         Optional<ApplicationCommandType> type = default,
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
-        Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
+        Optional<IDiscordPermissionSet?> defaultMemberPermissions = default,
         Optional<bool?> dmPermission = default,
         CancellationToken ct = default
     )
@@ -213,7 +213,7 @@ public class DiscordRestApplicationAPI : AbstractDiscordRestAPI, IDiscordRestApp
         Optional<IReadOnlyList<IApplicationCommandOption>?> options = default,
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
-        Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
+        Optional<IDiscordPermissionSet?> defaultMemberPermissions = default,
         Optional<bool?> dmPermission = default,
         CancellationToken ct = default
     )
@@ -361,7 +361,7 @@ public class DiscordRestApplicationAPI : AbstractDiscordRestAPI, IDiscordRestApp
         Optional<ApplicationCommandType> type = default,
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
-        Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
+        Optional<IDiscordPermissionSet?> defaultMemberPermissions = default,
         CancellationToken ct = default
     )
     {
@@ -439,7 +439,7 @@ public class DiscordRestApplicationAPI : AbstractDiscordRestAPI, IDiscordRestApp
         Optional<IReadOnlyList<IApplicationCommandOption>?> options = default,
         Optional<IReadOnlyDictionary<string, string>?> nameLocalizations = default,
         Optional<IReadOnlyDictionary<string, string>?> descriptionLocalizations = default,
-        Optional<IDiscordPermissionSet> defaultMemberPermissions = default,
+        Optional<IDiscordPermissionSet?> defaultMemberPermissions = default,
         CancellationToken ct = default
     )
     {


### PR DESCRIPTION
Some methods have incorrect type for `defaultMemberPermissions` parameter, docs refer to it as `default_member_permissions?	?string`.
In code they are currently `Optional<IDiscordPermissionSet>`, but it should be `Optional<IDiscordPermissionSet?>`

Affected methods:
- `CreateGlobalApplicationCommandAsync`
- `EditGlobalApplicationCommandAsync`
- `CreateGuildApplicationCommandAsync`
- `EditGuildApplicationCommandAsync`