### PR TITLE
Add customization and parallelization to responder dispatching

### DIFF
--- a/Backend/Remora.Discord.Gateway/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/Remora.Discord.Gateway/Extensions/ServiceCollectionExtensions.cs
@@ -49,14 +49,12 @@ public static class ServiceCollectionExtensions
     /// <param name="serviceCollection">The service collection.</param>
     /// <param name="tokenFactory">A function that retrieves the bot token.</param>
     /// <param name="buildClient">Extra options to configure the rest client.</param>
-    /// <param name="maxDispatchItems">How many items can be concurrently queued for dispatch.</param>
     /// <returns>The service collection, with the services added.</returns>
     public static IServiceCollection AddDiscordGateway
     (
         this IServiceCollection serviceCollection,
         Func<IServiceProvider, string> tokenFactory,
-        Action<IHttpClientBuilder>? buildClient = null,
-        int maxDispatchItems = 100
+        Action<IHttpClientBuilder>? buildClient = null
     )
     {
         serviceCollection
@@ -75,7 +73,7 @@ public static class ServiceCollectionExtensions
             s.GetRequiredService<ILogger<WebSocketPayloadTransportService>>()
         ));
 
-        serviceCollection.Configure<ResponderDispatchOptions>(dispatch => dispatch with { MaxItems = (uint)maxDispatchItems });
+        serviceCollection.Configure<ResponderDispatchOptions>(() => new());
 
         return serviceCollection;
     }

--- a/Backend/Remora.Discord.Gateway/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/Remora.Discord.Gateway/Extensions/ServiceCollectionExtensions.cs
@@ -33,6 +33,7 @@ using Remora.Discord.Gateway.Responders;
 using Remora.Discord.Gateway.Services;
 using Remora.Discord.Gateway.Transport;
 using Remora.Discord.Rest.Extensions;
+using Remora.Extensions.Options.Immutable;
 
 namespace Remora.Discord.Gateway.Extensions;
 
@@ -48,12 +49,14 @@ public static class ServiceCollectionExtensions
     /// <param name="serviceCollection">The service collection.</param>
     /// <param name="tokenFactory">A function that retrieves the bot token.</param>
     /// <param name="buildClient">Extra options to configure the rest client.</param>
+    /// <param name="maxDispatchItems">How many items can be concurrently queued for dispatch.</param>
     /// <returns>The service collection, with the services added.</returns>
     public static IServiceCollection AddDiscordGateway
     (
         this IServiceCollection serviceCollection,
         Func<IServiceProvider, string> tokenFactory,
-        Action<IHttpClientBuilder>? buildClient = null
+        Action<IHttpClientBuilder>? buildClient = null,
+        int maxDispatchItems = 100
     )
     {
         serviceCollection
@@ -71,6 +74,8 @@ public static class ServiceCollectionExtensions
             s.GetRequiredService<IOptionsMonitor<JsonSerializerOptions>>().Get("Discord"),
             s.GetRequiredService<ILogger<WebSocketPayloadTransportService>>()
         ));
+
+        serviceCollection.Configure<ResponderDispatchOptions>(dispatch => dispatch with { MaxItems = (uint)maxDispatchItems });
 
         return serviceCollection;
     }

--- a/Backend/Remora.Discord.Gateway/Remora.Discord.Gateway.csproj
+++ b/Backend/Remora.Discord.Gateway/Remora.Discord.Gateway.csproj
@@ -17,6 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="Remora.Extensions.Options.Immutable" Version="1.0.3" />
       <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
     </ItemGroup>
 </Project>

--- a/Backend/Remora.Discord.Gateway/ResponderDispatchOptions.cs
+++ b/Backend/Remora.Discord.Gateway/ResponderDispatchOptions.cs
@@ -20,6 +20,8 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+using Remora.Discord.Gateway.Services;
+
 namespace Remora.Discord.Gateway;
 
 /// <summary>

--- a/Backend/Remora.Discord.Gateway/ResponderDispatchOptions.cs
+++ b/Backend/Remora.Discord.Gateway/ResponderDispatchOptions.cs
@@ -25,13 +25,5 @@ namespace Remora.Discord.Gateway;
 /// <summary>
 ///  Represents options related to <see cref="ResponderDispatchService"/>.
 /// </summary>
-/// <param name="MaxItems">If <paramref name="EnableParallelDispatch"/> is <c>false</c>, how many items can be queued for dispatch at any given time.</param>
-/// <param name="MaxParallelism">How many threads can concurrently be used for dispatch. If <paramref name="EnableParallelDispatch"/> is false, this has no effect.</param>
-/// <param name="EnableParallelDispatch">Whether to enable paralell dispatching. While this may have positive performance impacts, events may be dispatched out of order.
-/// Intra-responder dispatch order is preserved, however.</param>
-/// <remarks>
-/// Parallelism may improve performance, but may also cause events to be processed out of order. e.g: MessageDelete firing before a MessageCreate.
-/// This can also cause some race conditions when it comes to the state of caching entities, and is only recommended if you've ensured it has no significant impact
-/// on the operation of your application.
-/// </remarks>
-public record ResponderDispatchOptions(uint MaxItems = 100, uint? MaxParallelism = null, bool EnableParallelDispatch = false);
+/// <param name="MaxItems">How many items can be queued for dispatch at any given time.</param>
+public record ResponderDispatchOptions(uint MaxItems = 100);

--- a/Backend/Remora.Discord.Gateway/ResponderDispatchOptions.cs
+++ b/Backend/Remora.Discord.Gateway/ResponderDispatchOptions.cs
@@ -1,0 +1,37 @@
+//
+//  ResponderDispatchOptions.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+namespace Remora.Discord.Gateway;
+
+/// <summary>
+///  Represents options related to <see cref="ResponderDispatchService"/>.
+/// </summary>
+/// <param name="MaxItems">If <paramref name="EnableParallelDispatch"/> is <c>false</c>, how many items can be queued for dispatch at any given time.</param>
+/// <param name="MaxParallelism">How many threads can concurrently be used for dispatch. If <paramref name="EnableParallelDispatch"/> is false, this has no effect.</param>
+/// <param name="EnableParallelDispatch">Whether to enable paralell dispatching. While this may have positive performance impacts, events may be dispatched out of order.
+/// Intra-responder dispatch order is preserved, however.</param>
+/// <remarks>
+/// Parallelism may improve performance, but may also cause events to be processed out of order. e.g: MessageDelete firing before a MessageCreate.
+/// This can also cause some race conditions when it comes to the state of caching entities, and is only recommended if you've ensured it has no significant impact
+/// on the operation of your application.
+/// </remarks>
+public record ResponderDispatchOptions(uint MaxItems = 100, uint? MaxParallelism = null, bool EnableParallelDispatch = false);

--- a/Backend/Remora.Discord.Gateway/Services/ResponderDispatchService.cs
+++ b/Backend/Remora.Discord.Gateway/Services/ResponderDispatchService.cs
@@ -157,7 +157,7 @@ public class ResponderDispatchService : IAsyncDisposable
 
         _respondersToFinalize = Channel.CreateUnbounded<Task<IReadOnlyList<Result>>>();
 
-        if (_options.EnableParallelDispatch)
+        if (!_options.EnableParallelDispatch)
         {
             _dispatcher = Task.Run(() => DispatcherTaskAsync(0), _dispatchCancellationSource.Token);
         }

--- a/Tests/Remora.Discord.Gateway.Tests/Remora.Discord.Gateway.Tests.csproj
+++ b/Tests/Remora.Discord.Gateway.Tests/Remora.Discord.Gateway.Tests.csproj
@@ -12,6 +12,7 @@
     <ItemGroup>
       <PackageReference Include="Moq" Version="4.18.1" />
       <PackageReference Include="OneOf" Version="3.0.216" />
+      <PackageReference Include="Remora.Extensions.Options.Immutable" Version="1.0.3" />
     </ItemGroup>
 
 </Project>

--- a/Tests/Remora.Discord.Gateway.Tests/Tests/DiscordGatewayClientTests.cs
+++ b/Tests/Remora.Discord.Gateway.Tests/Tests/DiscordGatewayClientTests.cs
@@ -28,6 +28,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using Moq;
 using Remora.Discord.API.Abstractions;
 using Remora.Discord.API.Abstractions.Gateway.Bidirectional;
@@ -42,6 +43,7 @@ using Remora.Discord.Gateway.Services;
 using Remora.Discord.Gateway.Tests.Transport;
 using Remora.Discord.Gateway.Transport;
 using Remora.Discord.Tests;
+using Remora.Extensions.Options.Immutable;
 using Remora.Results;
 using Xunit;
 
@@ -101,6 +103,7 @@ public class DiscordGatewayClientTests
         var transportMockDescriptor = ServiceDescriptor.Singleton(typeof(IPayloadTransportService), transportMock);
 
         var services = new ServiceCollection()
+            .Configure<ResponderDispatchOptions>(() => new())
             .AddDiscordGateway(_ => Constants.MockToken)
             .Replace(transportMockDescriptor)
             .Replace(CreateMockedGatewayAPI())
@@ -174,6 +177,7 @@ public class DiscordGatewayClientTests
         var transportMockDescriptor = ServiceDescriptor.Singleton(typeof(IPayloadTransportService), transportMock);
 
         var services = new ServiceCollection()
+            .Configure<ResponderDispatchOptions>(() => new())
             .AddDiscordGateway(_ => Constants.MockToken)
             .Replace(transportMockDescriptor)
             .Replace(CreateMockedGatewayAPI())
@@ -267,6 +271,7 @@ public class DiscordGatewayClientTests
         var transportMockDescriptor = ServiceDescriptor.Singleton(typeof(IPayloadTransportService), transportMock);
 
         var services = new ServiceCollection()
+            .Configure<ResponderDispatchOptions>(() => new())
             .AddDiscordGateway(_ => Constants.MockToken)
             .Replace(transportMockDescriptor)
             .Replace(CreateMockedGatewayAPI())
@@ -342,6 +347,7 @@ public class DiscordGatewayClientTests
         var transportMockDescriptor = ServiceDescriptor.Singleton(typeof(IPayloadTransportService), transportMock);
 
         var services = new ServiceCollection()
+            .Configure<ResponderDispatchOptions>(() => new())
             .AddDiscordGateway(_ => Constants.MockToken)
             .Replace(transportMockDescriptor)
             .Replace(CreateMockedGatewayAPI())
@@ -417,6 +423,7 @@ public class DiscordGatewayClientTests
         var transportMockDescriptor = ServiceDescriptor.Singleton(typeof(IPayloadTransportService), transportMock);
 
         var services = new ServiceCollection()
+            .Configure<ResponderDispatchOptions>(() => new())
             .AddDiscordGateway(_ => Constants.MockToken)
             .Replace(transportMockDescriptor)
             .Replace(CreateMockedGatewayAPI())
@@ -523,6 +530,7 @@ public class DiscordGatewayClientTests
         var transportMockDescriptor = ServiceDescriptor.Singleton(typeof(IPayloadTransportService), transportMock);
 
         var services = new ServiceCollection()
+            .Configure<ResponderDispatchOptions>(() => new())
             .AddDiscordGateway(_ => Constants.MockToken)
             .Replace(transportMockDescriptor)
             .Replace(CreateMockedGatewayAPI())

--- a/Tests/Remora.Discord.Gateway.Tests/Tests/DiscordGatewayClientTests.cs
+++ b/Tests/Remora.Discord.Gateway.Tests/Tests/DiscordGatewayClientTests.cs
@@ -103,7 +103,6 @@ public class DiscordGatewayClientTests
         var transportMockDescriptor = ServiceDescriptor.Singleton(typeof(IPayloadTransportService), transportMock);
 
         var services = new ServiceCollection()
-            .Configure<ResponderDispatchOptions>(() => new())
             .AddDiscordGateway(_ => Constants.MockToken)
             .Replace(transportMockDescriptor)
             .Replace(CreateMockedGatewayAPI())
@@ -177,7 +176,6 @@ public class DiscordGatewayClientTests
         var transportMockDescriptor = ServiceDescriptor.Singleton(typeof(IPayloadTransportService), transportMock);
 
         var services = new ServiceCollection()
-            .Configure<ResponderDispatchOptions>(() => new())
             .AddDiscordGateway(_ => Constants.MockToken)
             .Replace(transportMockDescriptor)
             .Replace(CreateMockedGatewayAPI())
@@ -271,7 +269,6 @@ public class DiscordGatewayClientTests
         var transportMockDescriptor = ServiceDescriptor.Singleton(typeof(IPayloadTransportService), transportMock);
 
         var services = new ServiceCollection()
-            .Configure<ResponderDispatchOptions>(() => new())
             .AddDiscordGateway(_ => Constants.MockToken)
             .Replace(transportMockDescriptor)
             .Replace(CreateMockedGatewayAPI())
@@ -347,7 +344,6 @@ public class DiscordGatewayClientTests
         var transportMockDescriptor = ServiceDescriptor.Singleton(typeof(IPayloadTransportService), transportMock);
 
         var services = new ServiceCollection()
-            .Configure<ResponderDispatchOptions>(() => new())
             .AddDiscordGateway(_ => Constants.MockToken)
             .Replace(transportMockDescriptor)
             .Replace(CreateMockedGatewayAPI())
@@ -423,7 +419,6 @@ public class DiscordGatewayClientTests
         var transportMockDescriptor = ServiceDescriptor.Singleton(typeof(IPayloadTransportService), transportMock);
 
         var services = new ServiceCollection()
-            .Configure<ResponderDispatchOptions>(() => new())
             .AddDiscordGateway(_ => Constants.MockToken)
             .Replace(transportMockDescriptor)
             .Replace(CreateMockedGatewayAPI())
@@ -530,7 +525,6 @@ public class DiscordGatewayClientTests
         var transportMockDescriptor = ServiceDescriptor.Singleton(typeof(IPayloadTransportService), transportMock);
 
         var services = new ServiceCollection()
-            .Configure<ResponderDispatchOptions>(() => new())
             .AddDiscordGateway(_ => Constants.MockToken)
             .Replace(transportMockDescriptor)
             .Replace(CreateMockedGatewayAPI())


### PR DESCRIPTION
This PR adds the ability to cuztomize and parallelize dispatch of responders. This is certainly tuned toward larger bots, but could bring some performance benefits overall.

It's worth noting that in very high throughput situations, parallelizing dispatch can cause race conditions in entity states, especially if using a backing store such as Redis.