### PR TITLE
Remove deprecated prefix in IIdentify connection fields [API v11]

### DIFF
--- a/Backend/Remora.Discord.API/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/Remora.Discord.API/Extensions/ServiceCollectionExtensions.cs
@@ -145,9 +145,9 @@ public static class ServiceCollectionExtensions
         options.AddDataObjectConverter<IIdentify, Identify>();
 
         options.AddDataObjectConverter<IConnectionProperties, ConnectionProperties>()
-            .WithPropertyName(p => p.OperatingSystem, "$os")
-            .WithPropertyName(p => p.Browser, "$browser")
-            .WithPropertyName(p => p.Device, "$device");
+            .WithPropertyName(p => p.OperatingSystem, "os")
+            .WithPropertyName(p => p.Browser, "browser")
+            .WithPropertyName(p => p.Device, "device");
 
         options.AddConverter<ShardIdentificationConverter>();
 

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Commands/IDENTIFY/IDENTIFY.OMIT_NULLS.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Commands/IDENTIFY/IDENTIFY.OMIT_NULLS.json
@@ -3,9 +3,9 @@
   "d": {
     "token": "none",
     "properties": {
-      "$os": "linux",
-      "$browser": "disco",
-      "$device": "disco"
+      "os": "linux",
+      "browser": "disco",
+      "device": "disco"
     },
     "compress": true,
     "large_threshold": 250,

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Commands/IDENTIFY/IDENTIFY.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Commands/IDENTIFY/IDENTIFY.json
@@ -3,9 +3,9 @@
   "d": {
     "token": "none",
     "properties": {
-      "$os": "linux",
-      "$browser": "disco",
-      "$device": "disco"
+      "os": "linux",
+      "browser": "disco",
+      "device": "disco"
     },
     "compress": true,
     "large_threshold": 250,

--- a/Tests/Remora.Discord.Tests/Samples/Objects/CONNECTION_PROPERTIES/CONNECTION_PROPERTIES.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/CONNECTION_PROPERTIES/CONNECTION_PROPERTIES.json
@@ -1,5 +1,5 @@
 {
-    "$os": "linux",
-    "$browser": "disco",
-    "$device": "disco"
+    "os": "linux",
+    "browser": "disco",
+    "device": "disco"
 }


### PR DESCRIPTION
Fixes #205.