### PR TITLE
Attempt to eliminate annoying stack trace that gets logged when socket gets aborted.

### DIFF
--- a/Backend/Remora.Discord.Gateway/DiscordGatewayClient.cs
+++ b/Backend/Remora.Discord.Gateway/DiscordGatewayClient.cs
@@ -1047,16 +1047,6 @@ public class DiscordGatewayClient : IDisposable
 
                 var receivedAt = DateTime.UtcNow;
 
-                if (receivedPayload.Error is Results.WebSocketError { State: WebSocketState.Aborted })
-                {
-                    // request reconnect.
-                    _shouldReconnect = true;
-
-                    // idk if connection is resumable.
-                    _isSessionResumable = false;
-                    return Result.FromSuccess();
-                }
-
                 if (!receivedPayload.IsSuccess)
                 {
                     // Normal closures are okay

--- a/Backend/Remora.Discord.Gateway/DiscordGatewayClient.cs
+++ b/Backend/Remora.Discord.Gateway/DiscordGatewayClient.cs
@@ -1047,6 +1047,16 @@ public class DiscordGatewayClient : IDisposable
 
                 var receivedAt = DateTime.UtcNow;
 
+                if (receivedPayload.Error is Results.WebSocketError { State: WebSocketState.Aborted })
+                {
+                    // request reconnect.
+                    _shouldReconnect = true;
+
+                    // idk if connection is resumable.
+                    _isSessionResumable = false;
+                    return Result.FromSuccess();
+                }
+
                 if (!receivedPayload.IsSuccess)
                 {
                     // Normal closures are okay


### PR DESCRIPTION
I think doing this instead of logging it's exception should be better than how it is currently. Aborted sockets cant be avoided, however it's stack trace on being logged I think can.