### PR TITLE
Externalize adding of Authorization header

### DIFF
--- a/Backend/Remora.Discord.Gateway/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/Remora.Discord.Gateway/Extensions/ServiceCollectionExtensions.cs
@@ -32,6 +32,7 @@ using Microsoft.Extensions.Options;
 using Remora.Discord.Gateway.Responders;
 using Remora.Discord.Gateway.Services;
 using Remora.Discord.Gateway.Transport;
+using Remora.Discord.Rest;
 using Remora.Discord.Rest.Extensions;
 using Remora.Extensions.Options.Immutable;
 
@@ -58,7 +59,11 @@ public static class ServiceCollectionExtensions
     )
     {
         serviceCollection
-            .AddDiscordRest(tokenFactory, buildClient);
+            .AddDiscordRest
+            (
+                s => (tokenFactory(s), DiscordTokenType.Bot),
+                buildClient
+            );
 
         serviceCollection.TryAddSingleton<Random>();
         serviceCollection.TryAddSingleton<ResponderDispatchService>();

--- a/Backend/Remora.Discord.Rest/Constants.cs
+++ b/Backend/Remora.Discord.Rest/Constants.cs
@@ -21,8 +21,11 @@
 //
 
 using System;
+using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions;
+
+[assembly: InternalsVisibleTo("Remora.Discord.Rest.Tests")]
 
 namespace Remora.Discord.Rest;
 
@@ -66,6 +69,11 @@ public static class Constants
     /// Gets the name of the locale header, used when requesting localized objects.
     /// </summary>
     public static string LocaleHeaderName { get; } = "X-Discord-Locale";
+
+    /// <summary>
+    /// Gets the global rate limit count.
+    /// </summary>
+    internal static int GlobalRateLimit { get; } = 50;
 
     /// <summary>
     /// Gets the name of the property, used when adding of Authorization should be skipped.

--- a/Backend/Remora.Discord.Rest/Constants.cs
+++ b/Backend/Remora.Discord.Rest/Constants.cs
@@ -66,4 +66,9 @@ public static class Constants
     /// Gets the name of the locale header, used when requesting localized objects.
     /// </summary>
     public static string LocaleHeaderName { get; } = "X-Discord-Locale";
+
+    /// <summary>
+    /// Gets the name of the property, used when adding of Authorization should be skipped.
+    /// </summary>
+    internal static string SkipAuthorizationPropertyName { get; } = "remora::skip-authorization";
 }

--- a/Backend/Remora.Discord.Rest/Constants.cs
+++ b/Backend/Remora.Discord.Rest/Constants.cs
@@ -71,4 +71,11 @@ public static class Constants
     /// Gets the name of the property, used when adding of Authorization should be skipped.
     /// </summary>
     internal static string SkipAuthorizationPropertyName { get; } = "remora::skip-authorization";
+
+#if NET5_0_OR_GREATER
+    /// <summary>
+    /// Gets the HTTP request option, used when adding of Authorization should be skipped.
+    /// </summary>
+    internal static System.Net.Http.HttpRequestOptionsKey<bool> SkipAuthorizationOption { get; } = new(SkipAuthorizationPropertyName);
+#endif
 }

--- a/Backend/Remora.Discord.Rest/DiscordTokenType.cs
+++ b/Backend/Remora.Discord.Rest/DiscordTokenType.cs
@@ -1,5 +1,5 @@
 //
-//  TokenStore.cs
+//  DiscordTokenType.cs
 //
 //  Author:
 //       Jarl Gullberg <jarl.gullberg@gmail.com>
@@ -25,25 +25,18 @@ using JetBrains.Annotations;
 namespace Remora.Discord.Rest;
 
 /// <summary>
-/// Represents a storage class for a single token.
+/// Enumerates various token types.
 /// </summary>
 [PublicAPI]
-public class TokenStore : ITokenStore
+public enum DiscordTokenType
 {
-    /// <inheritdoc />
-    public string Token { get; }
-
-    /// <inheritdoc />
-    public DiscordTokenType TokenType { get; }
+    /// <summary>
+    /// The token gained by registering a bot.
+    /// </summary>
+    Bot,
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="TokenStore"/> class.
+    /// The token gained through OAuth2 API.
     /// </summary>
-    /// <param name="token">The token to store.</param>
-    /// <param name="tokenType">The type of token to store.</param>
-    public TokenStore(string token, DiscordTokenType tokenType)
-    {
-        this.Token = token;
-        this.TokenType = tokenType;
-    }
+    Bearer
 }

--- a/Backend/Remora.Discord.Rest/Extensions/HttpRequestMessageExtensions.cs
+++ b/Backend/Remora.Discord.Rest/Extensions/HttpRequestMessageExtensions.cs
@@ -1,0 +1,56 @@
+//
+//  HttpRequestMessageExtensions.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Net.Http;
+using Polly;
+
+namespace Remora.Discord.Rest.Extensions;
+
+/// <summary>
+/// Defines extensions to the <see cref="HttpRequestMessage"/> class.
+/// </summary>
+internal static class HttpRequestMessageExtensions
+{
+    /// <summary>
+    /// Modifies the policy execution context of supplied HTTP request.
+    /// </summary>
+    /// <remarks>
+    /// Ensures that a policy execution context is set for supplied HTTP request.
+    /// </remarks>
+    /// <param name="request">The HTTP request.</param>
+    /// <param name="modifyContext">The action that modifies the context.</param>
+    /// <returns>The HTTP request that policy execution context was modified.</returns>
+    public static HttpRequestMessage ModifyPolicyExecutionContext(this HttpRequestMessage request, Action<Context> modifyContext)
+    {
+        var context = request.GetPolicyExecutionContext();
+        if (context is null)
+        {
+            context = new Context();
+            request.SetPolicyExecutionContext(context);
+        }
+
+        modifyContext(context);
+
+        return request;
+    }
+}

--- a/Backend/Remora.Discord.Rest/Extensions/RestRequestBuilderExtensions.cs
+++ b/Backend/Remora.Discord.Rest/Extensions/RestRequestBuilderExtensions.cs
@@ -62,14 +62,14 @@ public static class RestRequestBuilderExtensions
         bool isExemptFromGlobalLimits = false
     )
     {
-        var context = new Context
+        void ModifyContext(Context context)
         {
-            { "endpoint", builder.Endpoint },
-            { "cache", cache },
-            { "exempt-from-global-rate-limits", isExemptFromGlobalLimits }
-        };
+            context.Add("endpoint", builder.Endpoint);
+            context.Add("cache", cache);
+            context.Add("exempt-from-global-rate-limits", isExemptFromGlobalLimits);
+        }
 
-        builder.With(r => r.SetPolicyExecutionContext(context));
+        builder.With(r => r.ModifyPolicyExecutionContext(ModifyContext));
 
         return builder;
     }
@@ -83,7 +83,11 @@ public static class RestRequestBuilderExtensions
         this RestRequestBuilder builder
     )
     {
+#if NET5_0_OR_GREATER
+        builder.With(r => r.Options.Set(Constants.SkipAuthorizationOption, true));
+#else
         builder.With(r => r.Properties.Add(Constants.SkipAuthorizationPropertyName, true));
+#endif
 
         return builder;
     }

--- a/Backend/Remora.Discord.Rest/Extensions/RestRequestBuilderExtensions.cs
+++ b/Backend/Remora.Discord.Rest/Extensions/RestRequestBuilderExtensions.cs
@@ -73,4 +73,18 @@ public static class RestRequestBuilderExtensions
 
         return builder;
     }
+
+    /// <summary>
+    /// Adds an property to the request, used for skipping the addition of the Authorization header.
+    /// </summary>
+    /// <param name="builder">The request builder.</param>
+    /// <returns>The builder, with the property.</returns>
+    public static RestRequestBuilder SkipAuthorization(
+        this RestRequestBuilder builder
+    )
+    {
+        builder.With(r => r.Properties.Add(Constants.SkipAuthorizationPropertyName, true));
+
+        return builder;
+    }
 }

--- a/Backend/Remora.Discord.Rest/Handlers/AuthorizationHandler.cs
+++ b/Backend/Remora.Discord.Rest/Handlers/AuthorizationHandler.cs
@@ -1,0 +1,72 @@
+//
+//  AuthorizationHandler.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Remora.Discord.Rest.Handlers;
+
+/// <summary>
+/// Represents a delegating handler for adding the Authorization header.
+/// </summary>
+internal class AuthorizationHandler : DelegatingHandler
+{
+    private readonly ITokenStore _tokenStore;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuthorizationHandler"/> class.
+    /// </summary>
+    /// <param name="tokenStore">The token store.</param>
+    public AuthorizationHandler(ITokenStore tokenStore)
+    {
+        _tokenStore = tokenStore;
+    }
+
+    /// <inheritdoc />
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        if (!request.Properties.ContainsKey(Constants.SkipAuthorizationPropertyName))
+        {
+            AddAuthorizationHeader(request);
+        }
+
+        return base.SendAsync(request, cancellationToken);
+    }
+
+    private void AddAuthorizationHeader(HttpRequestMessage request)
+    {
+        var token = _tokenStore.Token;
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            throw new InvalidOperationException("The authentication token has to contain something.");
+        }
+
+        request.Headers.Authorization = new AuthenticationHeaderValue
+        (
+            "Bot",
+            token
+        );
+    }
+}

--- a/Backend/Remora.Discord.Rest/ITokenStore.cs
+++ b/Backend/Remora.Discord.Rest/ITokenStore.cs
@@ -34,4 +34,9 @@ public interface ITokenStore
     /// Gets the token.
     /// </summary>
     string Token { get; }
+
+    /// <summary>
+    /// Gets the type of the token.
+    /// </summary>
+    DiscordTokenType TokenType { get; }
 }

--- a/Tests/Remora.Discord.Commands.Tests/ContextTests.cs
+++ b/Tests/Remora.Discord.Commands.Tests/ContextTests.cs
@@ -53,7 +53,7 @@ public class ContextTests
     public ContextTests()
     {
         _services = new ServiceCollection()
-            .AddDiscordRest(_ => ("dummy", DiscordTokenType.Bearer))
+            .AddDiscordRest(_ => ("dummy", DiscordTokenType.Bot))
             .AddDiscordCommands()
             .AddCommandTree()
                 .WithCommandGroup<GroupWithContext>()

--- a/Tests/Remora.Discord.Commands.Tests/ContextTests.cs
+++ b/Tests/Remora.Discord.Commands.Tests/ContextTests.cs
@@ -31,6 +31,7 @@ using Remora.Discord.Commands.Contexts;
 using Remora.Discord.Commands.Extensions;
 using Remora.Discord.Commands.Services;
 using Remora.Discord.Commands.Tests.Data.Contexts;
+using Remora.Discord.Rest;
 using Remora.Discord.Rest.Extensions;
 using Remora.Discord.Tests;
 using Xunit;
@@ -52,7 +53,7 @@ public class ContextTests
     public ContextTests()
     {
         _services = new ServiceCollection()
-            .AddDiscordRest(_ => "dummy")
+            .AddDiscordRest(_ => ("dummy", DiscordTokenType.Bearer))
             .AddDiscordCommands()
             .AddCommandTree()
                 .WithCommandGroup<GroupWithContext>()

--- a/Tests/Remora.Discord.Commands.Tests/TestBases/CommandResponderTestBase.cs
+++ b/Tests/Remora.Discord.Commands.Tests/TestBases/CommandResponderTestBase.cs
@@ -24,6 +24,7 @@ using System;
 using Microsoft.Extensions.DependencyInjection;
 using Remora.Discord.Commands.Extensions;
 using Remora.Discord.Commands.Responders;
+using Remora.Discord.Rest;
 using Remora.Discord.Rest.Extensions;
 
 namespace Remora.Discord.Commands.Tests.TestBases;
@@ -46,7 +47,7 @@ public abstract class CommandResponderTestBase : IDisposable
     protected CommandResponderTestBase()
     {
         var serviceCollection = new ServiceCollection()
-            .AddDiscordRest(_ => "dummy")
+            .AddDiscordRest(_ => ("dummy", DiscordTokenType.Bearer))
             .AddDiscordCommands();
 
         // ReSharper disable once VirtualMemberCallInConstructor

--- a/Tests/Remora.Discord.Commands.Tests/TestBases/CommandResponderTestBase.cs
+++ b/Tests/Remora.Discord.Commands.Tests/TestBases/CommandResponderTestBase.cs
@@ -47,7 +47,7 @@ public abstract class CommandResponderTestBase : IDisposable
     protected CommandResponderTestBase()
     {
         var serviceCollection = new ServiceCollection()
-            .AddDiscordRest(_ => ("dummy", DiscordTokenType.Bearer))
+            .AddDiscordRest(_ => ("dummy", DiscordTokenType.Bot))
             .AddDiscordCommands();
 
         // ReSharper disable once VirtualMemberCallInConstructor

--- a/Tests/Remora.Discord.Rest.Tests/Polly/DiscordRateLimitPolicyTests.cs
+++ b/Tests/Remora.Discord.Rest.Tests/Polly/DiscordRateLimitPolicyTests.cs
@@ -1,0 +1,126 @@
+//
+//  DiscordRateLimitPolicyTests.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Polly;
+using Remora.Discord.Caching.Abstractions.Services;
+using Remora.Discord.Rest.Caching;
+using Remora.Discord.Rest.Polly;
+using Xunit;
+
+namespace Remora.Discord.Rest.Tests.Polly;
+
+/// <summary>
+/// Tests the <see cref="DiscordRateLimitPolicy" /> class.
+/// </summary>
+public class DiscordRateLimitPolicyTests
+{
+    private static ICacheProvider CreateCacheProvider()
+    {
+        var options = Options.Create(new MemoryCacheOptions());
+        var cache = new MemoryCache(options);
+        return new MemoryCacheProvider(cache);
+    }
+
+    private static DiscordRateLimitPolicy CreatePolicy()
+    {
+        return DiscordRateLimitPolicy.Create();
+    }
+
+    private static Context CreateContext(
+        string endpoint,
+        ICacheProvider cache,
+        bool isExemptFromGlobalLimits,
+        string? token = default)
+    {
+        var context = new Context
+        {
+            { "endpoint", endpoint },
+            { "cache", cache },
+            { "exempt-from-global-rate-limits", isExemptFromGlobalLimits }
+        };
+
+        if (token is not null)
+        {
+            context.Add("token", token);
+        }
+
+        return context;
+    }
+
+    /// <summary>
+    /// Tests whether global rate limit is enforced correctly.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task GlobalRateLimitEnforcedCorrectly()
+    {
+        var policy = CreatePolicy();
+        var cache = CreateCacheProvider();
+
+        var contextWithToken = CreateContext("dummy", cache, false, "MySecretToken");
+
+        var apiResponse = new HttpResponseMessage(HttpStatusCode.OK);
+
+        for (var i = 1; i <= Constants.GlobalRateLimit + 1; ++i)
+        {
+            var policyResponse = await policy.ExecuteAsync(_ => Task.FromResult(apiResponse), contextWithToken);
+            Assert.Equal(i <= Constants.GlobalRateLimit ? HttpStatusCode.OK : HttpStatusCode.TooManyRequests, policyResponse.StatusCode);
+        }
+    }
+
+    /// <summary>
+    /// Tests whether global rate limit per token is enforced correctly.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task GlobalRateLimitPerTokenEnforcedCorrectly()
+    {
+        var policy = CreatePolicy();
+        var cache = CreateCacheProvider();
+
+        var contextWithoutToken = CreateContext("dummy", cache, false);
+        var contextWithToken = CreateContext("dummy", cache, false, "MySecretToken");
+
+        var apiResponse = new HttpResponseMessage(HttpStatusCode.OK);
+        HttpResponseMessage policyResponse;
+
+        // Trigger global rate limit for token
+        for (var i = 1; i <= Constants.GlobalRateLimit + 1; ++i)
+        {
+            policyResponse = await policy.ExecuteAsync(_ => Task.FromResult(apiResponse), contextWithToken);
+            Assert.Equal(i <= Constants.GlobalRateLimit ? HttpStatusCode.OK : HttpStatusCode.TooManyRequests, policyResponse.StatusCode);
+        }
+
+        // Verify that requests without token is not rate limited.
+        policyResponse = await policy.ExecuteAsync(_ => Task.FromResult(apiResponse), contextWithoutToken);
+        Assert.Equal(HttpStatusCode.OK, policyResponse.StatusCode);
+
+        // Verify that requests with token is still rate limited.
+        policyResponse = await policy.ExecuteAsync(_ => Task.FromResult(apiResponse), contextWithToken);
+        Assert.Equal(HttpStatusCode.TooManyRequests, policyResponse.StatusCode);
+    }
+}

--- a/Tests/Remora.Discord.Rest.Tests/Polly/DiscordRateLimitPolicyTests.cs
+++ b/Tests/Remora.Discord.Rest.Tests/Polly/DiscordRateLimitPolicyTests.cs
@@ -50,11 +50,13 @@ public class DiscordRateLimitPolicyTests
         return DiscordRateLimitPolicy.Create();
     }
 
-    private static Context CreateContext(
+    private static Context CreateContext
+    (
         string endpoint,
         ICacheProvider cache,
         bool isExemptFromGlobalLimits,
-        string? token = default)
+        string? token = default
+    )
     {
         var context = new Context
         {

--- a/Tests/Remora.Discord.Rest.Tests/TestBases/RestAPITestBase.cs
+++ b/Tests/Remora.Discord.Rest.Tests/TestBases/RestAPITestBase.cs
@@ -55,7 +55,7 @@ public abstract class RestAPITestBase<TAPI> where TAPI : notnull
         var serviceContainer = new ServiceCollection()
             .AddDiscordRest
             (
-                _ => "TEST_TOKEN",
+                _ => ("TEST_TOKEN", DiscordTokenType.Bearer),
                 b => b.ConfigurePrimaryHttpMessageHandler
                 (
                     _ =>

--- a/Tests/Remora.Discord.Rest.Tests/TestBases/RestAPITestBase.cs
+++ b/Tests/Remora.Discord.Rest.Tests/TestBases/RestAPITestBase.cs
@@ -55,7 +55,7 @@ public abstract class RestAPITestBase<TAPI> where TAPI : notnull
         var serviceContainer = new ServiceCollection()
             .AddDiscordRest
             (
-                _ => ("TEST_TOKEN", DiscordTokenType.Bearer),
+                _ => ("TEST_TOKEN", DiscordTokenType.Bot),
                 b => b.ConfigurePrimaryHttpMessageHandler
                 (
                     _ =>

--- a/Tests/Remora.Discord.Tests/Tests/Core/TokenStore/TokenStoreTests.cs
+++ b/Tests/Remora.Discord.Tests/Tests/Core/TokenStore/TokenStoreTests.cs
@@ -41,9 +41,23 @@ public class TokenStoreTests
         [Fact]
         public void ReturnsCorrectValue()
         {
-            var tokenStore = new TokenStore("Hello world!");
+            var tokenStore = new TokenStore("Hello world!", DiscordTokenType.Bearer);
 
             Assert.Equal("Hello world!", tokenStore.Token);
+        }
+    }
+
+    /// <summary>
+    /// Tests the <see cref="TokenStore.TokenType"/> property.
+    /// </summary>
+    public class TokenType
+    {
+        [Fact]
+        public void ReturnsCorrectValue()
+        {
+            var tokenStore = new TokenStore("Hello world!", DiscordTokenType.Bearer);
+
+            Assert.Equal(DiscordTokenType.Bearer, tokenStore.TokenType);
         }
     }
 }

--- a/Tests/Remora.Discord.Tests/Tests/Core/TokenStore/TokenStoreTests.cs
+++ b/Tests/Remora.Discord.Tests/Tests/Core/TokenStore/TokenStoreTests.cs
@@ -53,7 +53,15 @@ public class TokenStoreTests
     public class TokenType
     {
         [Fact]
-        public void ReturnsCorrectValue()
+        public void ReturnsCorrectValueForBotTokenType()
+        {
+            var tokenStore = new TokenStore("Hello world!", DiscordTokenType.Bot);
+
+            Assert.Equal(DiscordTokenType.Bot, tokenStore.TokenType);
+        }
+
+        [Fact]
+        public void ReturnsCorrectValueForBearerTokenType()
         {
             var tokenStore = new TokenStore("Hello world!", DiscordTokenType.Bearer);
 


### PR DESCRIPTION
In the following the Authrization Header is now being added by a DelegatinHandler.
This allows to skip the addition of the Authorization header in special cases. (e.g. WebHooks)

An extension method has been added to the RestRequestBuilder class to skip the authorization. `b.SkipAuthorization()`