### PR TITLE
Prune packages older than 5 versions.

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -47,15 +47,11 @@ jobs:
         with:
           name: nupkg
           path: nuget
-      - name: Push to GitHub Feed
-        run: |
-          for f in ./nuget/*; do
-            curl -vX PUT -u "$GITHUB_USER:$GITHUB_TOKEN" -F package=@$f $GITHUB_FEED
-          done
-      - name: Prune packages older than 5 versions
+      # To ensure that the current version being pushed does not get pruned we prune first.
+      - name: Prune packages older than 4 versions (new version is the 5th)
         uses: smartsquaregmbh/delete-old-packages@v0.4.0
         with:
-          keep: 5
+          keep: 4
           names: |
             Remora.Discord
             Remora.Discord.API
@@ -71,3 +67,8 @@ jobs:
             Remora.Discord.Commands
             Remora.Discord.Unstable
             Remora.Discord.Rest
+      - name: Push to GitHub Feed
+        run: |
+          for f in ./nuget/*; do
+            curl -vX PUT -u "$GITHUB_USER:$GITHUB_TOKEN" -F package=@$f $GITHUB_FEED
+          done

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -52,3 +52,22 @@ jobs:
           for f in ./nuget/*; do
             curl -vX PUT -u "$GITHUB_USER:$GITHUB_TOKEN" -F package=@$f $GITHUB_FEED
           done
+      - name: Prune packages older than 5 versions
+        uses: smartsquaregmbh/delete-old-packages@v0.4.0
+        with:
+          keep: 5
+          names: |
+            Remora.Discord
+            Remora.Discord.API
+            Remora.Discord.API.Abstractions
+            Remora.Discord.Caching
+            Remora.Discord.Caching.Abstractions
+            Remora.Discord.Caching.Redis
+            Remora.Discord.Gateway
+            Remora.Discord.Extensions
+            Remora.Discord.Hosting
+            Remora.Discord.Pagination
+            Remora.Discord.Interactivity
+            Remora.Discord.Commands
+            Remora.Discord.Unstable
+            Remora.Discord.Rest


### PR DESCRIPTION
I think storing only 5 of the bleeding edge package versions would help avoid going over github's 500 MB free limit which would save money 💵.