### PR TITLE
Allow Remora Plugins to add DiscordService using only service collection.

### DIFF
--- a/Remora.Discord.Hosting/Extensions/HostBuilderExtensions.cs
+++ b/Remora.Discord.Hosting/Extensions/HostBuilderExtensions.cs
@@ -23,12 +23,7 @@
 using System;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
-using Remora.Discord.Gateway.Extensions;
-using Remora.Discord.Hosting.Options;
-using Remora.Discord.Hosting.Services;
-using Remora.Extensions.Options.Immutable;
 
 namespace Remora.Discord.Hosting.Extensions;
 
@@ -43,23 +38,11 @@ public static class HostBuilderExtensions
     /// </summary>
     /// <param name="hostBuilder">The host builder.</param>
     /// <param name="tokenFactory">A function that retrieves the bot token.</param>
-    /// <returns>The service collection, with the services added.</returns>
+    /// <returns>The host builder, with the services added.</returns>
     public static IHostBuilder AddDiscordService(this IHostBuilder hostBuilder, Func<IServiceProvider, string> tokenFactory)
     {
         hostBuilder.ConfigureServices((_, serviceCollection) =>
-        {
-            serviceCollection.Configure(() => new DiscordServiceOptions());
-
-            serviceCollection
-                .AddDiscordGateway(tokenFactory);
-
-            serviceCollection
-                .TryAddSingleton<DiscordService>();
-
-            serviceCollection
-                .AddSingleton<IHostedService, DiscordService>(serviceProvider =>
-                    serviceProvider.GetRequiredService<DiscordService>());
-        });
+            serviceCollection.AddDiscordService(tokenFactory));
 
         return hostBuilder;
     }

--- a/Remora.Discord.Hosting/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Discord.Hosting/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,67 @@
+﻿//
+//  ServiceCollectionExtensions.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Remora.Discord.Gateway.Extensions;
+using Remora.Discord.Hosting.Options;
+using Remora.Discord.Hosting.Services;
+using Remora.Extensions.Options.Immutable;
+
+namespace Remora.Discord.Hosting.Extensions;
+
+/// <summary>
+/// Defines extension methods for the <see cref="IServiceCollection"/> interface.
+/// </summary>
+[PublicAPI]
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the required services for Remora Discord and a <see cref="IHostedService"/> implementation
+    /// using the service collection.
+    /// </summary>
+    /// <param name="serviceCollection">The service collection.</param>
+    /// <param name="tokenFactory">A function that retrieves the bot token.</param>
+    /// <returns>The service collection, with the services added.</returns>
+    public static IServiceCollection AddDiscordService
+    (
+        this IServiceCollection serviceCollection,
+        Func<IServiceProvider, string> tokenFactory
+    )
+    {
+        _ = serviceCollection.Configure(() => new DiscordServiceOptions());
+
+        _ = serviceCollection
+            .AddDiscordGateway(tokenFactory);
+
+        serviceCollection
+            .TryAddSingleton<DiscordService>();
+
+        _ = serviceCollection
+            .AddSingleton<IHostedService, DiscordService>(serviceProvider =>
+                serviceProvider.GetRequiredService<DiscordService>());
+        return serviceCollection;
+    }
+}

--- a/Remora.Discord.Hosting/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Discord.Hosting/Extensions/ServiceCollectionExtensions.cs
@@ -44,6 +44,7 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="serviceCollection">The service collection.</param>
     /// <param name="tokenFactory">A function that retrieves the bot token.</param>
+    /// <remarks>Only use this when the service collection is owned by an host builder.</remarks>
     /// <returns>The service collection, with the services added.</returns>
     public static IServiceCollection AddDiscordService
     (


### PR DESCRIPTION
Some people might prefer to use Remora.Plugins for providing all of the Discord Functionality in their programs. As such with this it gives them the ability to do so.