### PR TITLE
Skip authorization for Webhook endpoints that use a token

### DIFF
--- a/Backend/Remora.Discord.Rest/API/Webhooks/DiscordRestWebhookAPI.cs
+++ b/Backend/Remora.Discord.Rest/API/Webhooks/DiscordRestWebhookAPI.cs
@@ -160,7 +160,9 @@ public class DiscordRestWebhookAPI : AbstractDiscordRestAPI, IDiscordRestWebhook
         return this.RestHttpClient.GetAsync<IWebhook>
         (
             $"webhooks/{webhookID}/{token}",
-            b => b.WithRateLimitContext(this.RateLimitCache),
+            b => b
+                .WithRateLimitContext(this.RateLimitCache)
+                .SkipAuthorization(),
             ct: ct
         );
     }
@@ -233,7 +235,8 @@ public class DiscordRestWebhookAPI : AbstractDiscordRestAPI, IDiscordRestWebhook
                     }
                 )
                 .AddAuditLogReason(reason)
-                .WithRateLimitContext(this.RateLimitCache),
+                .WithRateLimitContext(this.RateLimitCache)
+                .SkipAuthorization(),
             ct: ct
         );
     }
@@ -266,7 +269,10 @@ public class DiscordRestWebhookAPI : AbstractDiscordRestAPI, IDiscordRestWebhook
         return this.RestHttpClient.DeleteAsync
         (
             $"webhooks/{webhookID}/{token}",
-            b => b.AddAuditLogReason(reason).WithRateLimitContext(this.RateLimitCache),
+            b => b
+                .AddAuditLogReason(reason)
+                .WithRateLimitContext(this.RateLimitCache)
+                .SkipAuthorization(),
             ct
         );
     }

--- a/Tests/Remora.Discord.Rest.Tests/API/Webhooks/DiscordRestWebhookAPITests.cs
+++ b/Tests/Remora.Discord.Rest.Tests/API/Webhooks/DiscordRestWebhookAPITests.cs
@@ -315,6 +315,7 @@ public class DiscordRestWebhookAPITests
             (
                 b => b
                     .Expect(HttpMethod.Get, $"{Constants.BaseURL}webhooks/{webhookID}/{token}")
+                    .With(m => m.Headers.Authorization == null)
                     .Respond("application/json", SampleRepository.Samples[typeof(IWebhook)])
             );
 
@@ -483,6 +484,7 @@ public class DiscordRestWebhookAPITests
                 b => b
                     .Expect(HttpMethod.Patch, $"{Constants.BaseURL}webhooks/{webhookId}/{token}")
                     .WithHeaders(Constants.AuditLogHeaderName, reason)
+                    .With(m => m.Headers.Authorization == null)
                     .Respond("application/json", SampleRepository.Samples[typeof(IWebhook)])
             );
 
@@ -621,6 +623,7 @@ public class DiscordRestWebhookAPITests
                 b => b
                     .Expect(HttpMethod.Delete, $"{Constants.BaseURL}webhooks/{webhookID}/{token}")
                     .WithHeaders(Constants.AuditLogHeaderName, reason)
+                    .With(m => m.Headers.Authorization == null)
                     .Respond(HttpStatusCode.NoContent)
             );
 


### PR DESCRIPTION
Some webhook endpoints rely on a token themself for authorization.
Therefore the authorization by header should be skipped.

## Affected Endpoints
- [Get Webhook with Token](https://discord.com/developers/docs/resources/webhook#get-webhook-with-token)
- [Modify Webhook with Token](https://discord.com/developers/docs/resources/webhook#modify-webhook-with-token)
- [Delete Webhook with Token](https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token)