### PR TITLE
Implement OAuth2 authorization flow (retrieve/revoke token)

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/OAuth2/GrantType.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/OAuth2/GrantType.cs
@@ -1,0 +1,47 @@
+//
+//  GrantType.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using JetBrains.Annotations;
+
+namespace Remora.Discord.API.Abstractions.Objects;
+
+/// <summary>
+/// Enumerates the various grant types.
+/// </summary>
+[PublicAPI]
+public enum GrantType
+{
+    /// <summary>
+    /// An authorization code grant.
+    /// </summary>
+    AuthorizationCode,
+
+    /// <summary>
+    /// A refresh token grant.
+    /// </summary>
+    RefreshToken,
+
+    /// <summary>
+    /// A client credentials grant.
+    /// </summary>
+    ClientCredentials,
+}

--- a/Backend/Remora.Discord.API.Abstractions/API/Objects/OAuth2/IAccessTokenInformation.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Objects/OAuth2/IAccessTokenInformation.cs
@@ -1,0 +1,59 @@
+//
+//  IAccessTokenInformation.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using JetBrains.Annotations;
+using Remora.Rest.Core;
+
+namespace Remora.Discord.API.Abstractions.Objects;
+
+/// <summary>
+/// Represents access token response information.
+/// </summary>
+[PublicAPI]
+public interface IAccessTokenInformation
+{
+    /// <summary>
+    /// Gets the access token.
+    /// </summary>
+    string AccessToken { get; }
+
+    /// <summary>
+    /// Gets the type of the access token.
+    /// </summary>
+    string TokenType { get; }
+
+    /// <summary>
+    /// Gets the duration of the access tokens validity.
+    /// </summary>
+    Optional<TimeSpan> ExpiresIn { get; }
+
+    /// <summary>
+    /// Gets the refresh token.
+    /// </summary>
+    Optional<string> RefreshToken { get; }
+
+    /// <summary>
+    /// Gets the scopes associated with this access token.
+    /// </summary>
+    Optional<string> Scope { get; }
+}

--- a/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestOAuth2API.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestOAuth2API.cs
@@ -20,10 +20,12 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
+using Remora.Rest.Core;
 using Remora.Results;
 
 namespace Remora.Discord.API.Abstractions.Rest;
@@ -51,6 +53,56 @@ public interface IDiscordRestOAuth2API
     /// <returns>A retrieval result which may or may not have succeeded.</returns>
     Task<Result<IAuthorizationInformation>> GetCurrentAuthorizationInformationAsync
     (
+        CancellationToken ct = default
+    );
+
+    /// <summary>
+    /// Gets the OAuth2 access and refresh tokens by authorization code.
+    /// </summary>
+    /// <param name="clientID">The application client ID.</param>
+    /// <param name="clientSecret">The application client secret.</param>
+    /// <param name="code">The code received from the code grant.</param>
+    /// <param name="redirectUri">The application redirect URI.</param>
+    /// <param name="ct">The cancellation token for this operation.</param>
+    /// <returns>A creation result which may or may not have succeeded.</returns>
+    Task<Result<IAccessTokenInformation>> GetTokenByAuthorizationCodeAsync
+    (
+        string clientID,
+        string clientSecret,
+        string code,
+        string redirectUri,
+        CancellationToken ct = default
+    );
+
+    /// <summary>
+    /// Gets the OAuth2 access and refresh tokens by refresh token.
+    /// </summary>
+    /// <param name="clientID">The application client ID.</param>
+    /// <param name="clientSecret">The application client secret.</param>
+    /// <param name="refreshToken">The refresh token received from authorization code grant.</param>
+    /// <param name="ct">The cancellation token for this operation.</param>
+    /// <returns>A creation result which may or may not have succeeded.</returns>
+    Task<Result<IAccessTokenInformation>> GetTokenByRefreshTokenAsync
+    (
+        string clientID,
+        string clientSecret,
+        string refreshToken,
+        CancellationToken ct = default
+    );
+
+    /// <summary>
+    /// Gets the OAuth2 access and refresh tokens by client credentials.
+    /// </summary>
+    /// <param name="clientID">The application client ID.</param>
+    /// <param name="clientSecret">The application client secret.</param>
+    /// <param name="scopes">The scopes to request.</param>
+    /// <param name="ct">The cancellation token for this operation.</param>
+    /// <returns>A creation result which may or may not have succeeded.</returns>
+    Task<Result<IAccessTokenInformation>> GetTokenByClientCredentialsAsync
+    (
+        string clientID,
+        string clientSecret,
+        IReadOnlyList<string> scopes,
         CancellationToken ct = default
     );
 }

--- a/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestOAuth2API.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Rest/IDiscordRestOAuth2API.cs
@@ -25,7 +25,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Remora.Discord.API.Abstractions.Objects;
-using Remora.Rest.Core;
 using Remora.Results;
 
 namespace Remora.Discord.API.Abstractions.Rest;
@@ -64,7 +63,7 @@ public interface IDiscordRestOAuth2API
     /// <param name="code">The code received from the code grant.</param>
     /// <param name="redirectUri">The application redirect URI.</param>
     /// <param name="ct">The cancellation token for this operation.</param>
-    /// <returns>A creation result which may or may not have succeeded.</returns>
+    /// <returns>A retrieval result which may or may not have succeeded.</returns>
     Task<Result<IAccessTokenInformation>> GetTokenByAuthorizationCodeAsync
     (
         string clientID,
@@ -81,7 +80,7 @@ public interface IDiscordRestOAuth2API
     /// <param name="clientSecret">The application client secret.</param>
     /// <param name="refreshToken">The refresh token received from authorization code grant.</param>
     /// <param name="ct">The cancellation token for this operation.</param>
-    /// <returns>A creation result which may or may not have succeeded.</returns>
+    /// <returns>A retrieval result which may or may not have succeeded.</returns>
     Task<Result<IAccessTokenInformation>> GetTokenByRefreshTokenAsync
     (
         string clientID,
@@ -97,12 +96,44 @@ public interface IDiscordRestOAuth2API
     /// <param name="clientSecret">The application client secret.</param>
     /// <param name="scopes">The scopes to request.</param>
     /// <param name="ct">The cancellation token for this operation.</param>
-    /// <returns>A creation result which may or may not have succeeded.</returns>
+    /// <returns>A retrieval result which may or may not have succeeded.</returns>
     Task<Result<IAccessTokenInformation>> GetTokenByClientCredentialsAsync
     (
         string clientID,
         string clientSecret,
         IReadOnlyList<string> scopes,
+        CancellationToken ct = default
+    );
+
+    /// <summary>
+    /// Revokes the OAuth2 access token.
+    /// </summary>
+    /// <param name="clientID">The application client ID.</param>
+    /// <param name="clientSecret">The application client secret.</param>
+    /// <param name="accessToken">The OAuth2 access token.</param>
+    /// <param name="ct">The cancellation token for this operation.</param>
+    /// <returns>A revocation result which may or may not have succeeded.</returns>
+    Task<Result> RevokeAccessTokenAsync
+    (
+        string clientID,
+        string clientSecret,
+        string accessToken,
+        CancellationToken ct = default
+    );
+
+    /// <summary>
+    /// Revokes the OAuth2 refresh token.
+    /// </summary>
+    /// <param name="clientID">The application client ID.</param>
+    /// <param name="clientSecret">The application client secret.</param>
+    /// <param name="refreshToken">The OAuth2 refresh token.</param>
+    /// <param name="ct">The cancellation token for this operation.</param>
+    /// <returns>A revocation result which may or may not have succeeded.</returns>
+    Task<Result> RevokeRefreshTokenAsync
+    (
+        string clientID,
+        string clientSecret,
+        string refreshToken,
         CancellationToken ct = default
     );
 }

--- a/Backend/Remora.Discord.API/API/Objects/OAuth2/AccessTokenInformation.cs
+++ b/Backend/Remora.Discord.API/API/Objects/OAuth2/AccessTokenInformation.cs
@@ -1,0 +1,39 @@
+//
+//  AccessTokenInformation.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using JetBrains.Annotations;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Rest.Core;
+
+namespace Remora.Discord.API.Objects;
+
+/// <inheritdoc cref="Remora.Discord.API.Abstractions.Objects.IAccessTokenInformation" />
+[PublicAPI]
+public record AccessTokenInformation
+(
+    string AccessToken,
+    string TokenType,
+    Optional<TimeSpan> ExpiresIn = default,
+    Optional<string> RefreshToken = default,
+    Optional<string> Scope = default
+) : IAccessTokenInformation;

--- a/Backend/Remora.Discord.API/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/Remora.Discord.API/Extensions/ServiceCollectionExtensions.cs
@@ -1011,6 +1011,9 @@ public static class ServiceCollectionExtensions
 
         options.AddDataObjectConverter<IAuthorizationInformation, AuthorizationInformation>();
 
+        options.AddDataObjectConverter<IAccessTokenInformation, AccessTokenInformation>()
+            .WithPropertyConverter(i => i.ExpiresIn, new UnitTimeSpanConverter(TimeUnit.Seconds));
+
         return options;
     }
 

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestOAuth2API.Delegations.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestOAuth2API.Delegations.cs
@@ -21,7 +21,12 @@
 //
 
 using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Remora.Discord.API.Abstractions.Objects;
 using Remora.Rest;
+using Remora.Results;
 
 namespace Remora.Discord.Caching.API;
 
@@ -48,5 +53,61 @@ public partial class CachingDiscordRestOAuth2API
         }
 
         customizable.RemoveCustomization(customization);
+    }
+
+    /// <inheritdoc/>
+    public Task<Result<IAccessTokenInformation>> GetTokenByAuthorizationCodeAsync
+    (
+        string clientID,
+        string clientSecret,
+        string code,
+        string redirectUri,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.GetTokenByAuthorizationCodeAsync
+        (
+            clientID,
+            clientSecret,
+            code,
+            redirectUri,
+            ct
+        );
+    }
+
+    /// <inheritdoc/>
+    public Task<Result<IAccessTokenInformation>> GetTokenByRefreshTokenAsync
+    (
+        string clientID,
+        string clientSecret,
+        string refreshToken,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.GetTokenByRefreshTokenAsync
+        (
+            clientID,
+            clientSecret,
+            refreshToken,
+            ct
+        );
+    }
+
+    /// <inheritdoc/>
+    public Task<Result<IAccessTokenInformation>> GetTokenByClientCredentialsAsync
+    (
+        string clientID,
+        string clientSecret,
+        IReadOnlyList<string> scopes,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.GetTokenByClientCredentialsAsync
+        (
+            clientID,
+            clientSecret,
+            scopes,
+            ct
+        );
     }
 }

--- a/Backend/Remora.Discord.Caching/API/CachingDiscordRestOAuth2API.Delegations.cs
+++ b/Backend/Remora.Discord.Caching/API/CachingDiscordRestOAuth2API.Delegations.cs
@@ -110,4 +110,40 @@ public partial class CachingDiscordRestOAuth2API
             ct
         );
     }
+
+    /// <inheritdoc/>
+    public Task<Result> RevokeAccessTokenAsync
+    (
+        string clientID,
+        string clientSecret,
+        string accessToken,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.RevokeAccessTokenAsync
+        (
+            clientID,
+            clientSecret,
+            accessToken,
+            ct
+        );
+    }
+
+    /// <inheritdoc/>
+    public Task<Result> RevokeRefreshTokenAsync
+    (
+        string clientID,
+        string clientSecret,
+        string refreshToken,
+        CancellationToken ct = default
+    )
+    {
+        return _actual.RevokeRefreshTokenAsync
+        (
+            clientID,
+            clientSecret,
+            refreshToken,
+            ct
+        );
+    }
 }

--- a/Backend/Remora.Discord.Rest/Extensions/ServiceCollectionExtensions.cs
+++ b/Backend/Remora.Discord.Rest/Extensions/ServiceCollectionExtensions.cs
@@ -44,6 +44,7 @@ using Remora.Discord.Rest.Handlers;
 using Remora.Discord.Rest.Polly;
 using Remora.Rest;
 using Remora.Rest.Extensions;
+using Remora.Rest.Json.Policies;
 
 namespace Remora.Discord.Rest.Extensions;
 
@@ -177,7 +178,8 @@ public static class ServiceCollectionExtensions
         (
             s.GetRequiredService<IRestHttpClient>(),
             s.GetRequiredService<IOptionsMonitor<JsonSerializerOptions>>().Get("Discord"),
-            s.GetRequiredService<ICacheProvider>()
+            s.GetRequiredService<ICacheProvider>(),
+            s.GetRequiredService<SnakeCaseNamingPolicy>()
         ));
 
         serviceCollection.TryAddTransient<IDiscordRestStageInstanceAPI>(s => new DiscordRestStageInstanceAPI

--- a/Tests/Remora.Discord.API.Tests/API/Objects/OAuth2/AccessTokenInformationTests.cs
+++ b/Tests/Remora.Discord.API.Tests/API/Objects/OAuth2/AccessTokenInformationTests.cs
@@ -1,0 +1,31 @@
+//
+//  AccessTokenInformationTests.cs
+//
+//  Author:
+//       Jarl Gullberg <jarl.gullberg@gmail.com>
+//
+//  Copyright (c) 2017 Jarl Gullberg
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.API.Tests.TestBases;
+
+namespace Remora.Discord.API.Tests.Objects;
+
+/// <inheritdoc />
+public class AccessTokenInformationTests : ObjectTestBase<IAccessTokenInformation>
+{
+}

--- a/Tests/Remora.Discord.Rest.Tests/API/OAuth2/DiscordRestOAuth2APITests.cs
+++ b/Tests/Remora.Discord.Rest.Tests/API/OAuth2/DiscordRestOAuth2APITests.cs
@@ -21,6 +21,7 @@
 //
 
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -209,6 +210,82 @@ public class DiscordRestOAuth2APITests
                 clientID,
                 clientSecret,
                 scopes
+            );
+            ResultAssert.Successful(result);
+        }
+    }
+
+    /// <summary>
+    /// Tests the <see cref="DiscordRestOAuth2API.RevokeAccessTokenAsync"/> method.
+    /// </summary>
+    public class RevokeAccessTokenAsync : RestAPITestBase<IDiscordRestOAuth2API>
+    {
+        /// <summary>
+        /// Tests whether the API method performs its request correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Fact]
+        public async Task PerformsRequestCorrectly()
+        {
+            var clientID = "123456789";
+            var clientSecret = "abcdefg";
+            var accessToken = "a1b2c3d4e5";
+
+            var api = CreateAPI
+            (
+                b => b
+                    .Expect(HttpMethod.Post, $"{Constants.BaseURL}oauth2/token/revoke")
+                    .With(m => !m.Headers.Contains("Authorization"))
+                    .WithFormData("client_id", clientID)
+                    .WithFormData("client_secret", clientSecret)
+                    .WithFormData("token", accessToken)
+                    .WithFormData("token_type_hint", "access_token")
+                    .Respond(HttpStatusCode.OK)
+            );
+
+            var result = await api.RevokeAccessTokenAsync
+            (
+                clientID,
+                clientSecret,
+                accessToken
+            );
+            ResultAssert.Successful(result);
+        }
+    }
+
+    /// <summary>
+    /// Tests the <see cref="DiscordRestOAuth2API.RevokeRefreshTokenAsync"/> method.
+    /// </summary>
+    public class RevokeRefreshTokenAsync : RestAPITestBase<IDiscordRestOAuth2API>
+    {
+        /// <summary>
+        /// Tests whether the API method performs its request correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Fact]
+        public async Task PerformsRequestCorrectly()
+        {
+            var clientID = "123456789";
+            var clientSecret = "abcdefg";
+            var refreshToken = "a1b2c3d4e5";
+
+            var api = CreateAPI
+            (
+                b => b
+                    .Expect(HttpMethod.Post, $"{Constants.BaseURL}oauth2/token/revoke")
+                    .With(m => !m.Headers.Contains("Authorization"))
+                    .WithFormData("client_id", clientID)
+                    .WithFormData("client_secret", clientSecret)
+                    .WithFormData("token", refreshToken)
+                    .WithFormData("token_type_hint", "refresh_token")
+                    .Respond(HttpStatusCode.OK)
+            );
+
+            var result = await api.RevokeRefreshTokenAsync
+            (
+                clientID,
+                clientSecret,
+                refreshToken
             );
             ResultAssert.Successful(result);
         }

--- a/Tests/Remora.Discord.Tests/Samples/Objects/ACCESS_TOKEN_INFORMATION/ACCESS_TOKEN_INFORMATION.json
+++ b/Tests/Remora.Discord.Tests/Samples/Objects/ACCESS_TOKEN_INFORMATION/ACCESS_TOKEN_INFORMATION.json
@@ -1,0 +1,7 @@
+{
+  "access_token": "6qrZcUqja7812RVdnEKjpzOL4CvHBFG",
+  "token_type": "Bearer",
+  "expires_in": 604800,
+  "refresh_token": "D43f5y0ahjqew82jZ4NViEr2YafMKhue",
+  "scope": "identify"
+}


### PR DESCRIPTION
This PR implements only the OAuth2 specific endpoints that make sense to be called by an application:
- Retrieve token: `oauth/token`
- Revoke token: `oauth/token/revoke`

The `oauth/authorize` endpoint is not to be called by an application but been opened by an actual user.
Therefore we could provide some builder for those URLs.


### Related issues
#210 (Missing mentioned builder for authorize URLs)