### PR TITLE
Support Resume Gateway URL

### DIFF
--- a/Backend/Remora.Discord.API.Abstractions/API/Gateway/Events/ConnectingResuming/IReady.cs
+++ b/Backend/Remora.Discord.API.Abstractions/API/Gateway/Events/ConnectingResuming/IReady.cs
@@ -55,6 +55,11 @@ public interface IReady : IGatewayEvent
     string SessionID { get; }
 
     /// <summary>
+    /// Gets the resume gateway URL.
+    /// </summary>
+    string ResumeGatewayUrl { get; }
+
+    /// <summary>
     /// Gets the shard information associated with this session.
     /// </summary>
     Optional<IShardIdentification> Shard { get; }

--- a/Backend/Remora.Discord.API/API/Gateway/Events/ConnectingResuming/Ready.cs
+++ b/Backend/Remora.Discord.API/API/Gateway/Events/ConnectingResuming/Ready.cs
@@ -39,6 +39,7 @@ public record Ready
     IUser User,
     IReadOnlyList<IUnavailableGuild> Guilds,
     string SessionID,
+    string ResumeGatewayUrl,
     Optional<IShardIdentification> Shard,
     IPartialApplication Application
 ) : IReady;

--- a/Tests/Remora.Discord.Gateway.Tests/Constants.cs
+++ b/Tests/Remora.Discord.Gateway.Tests/Constants.cs
@@ -55,5 +55,5 @@ public static class Constants
     /// <summary>
     /// Gets the default mocked resume gateway URL.
     /// </summary>
-    public static string MockResumeGatewayUrl => "wss://resume-gateway.discord.gg/";
+    public static string MockResumeGatewayUrl => "wss://us-east1-b.gateway.discord.gg";
 }

--- a/Tests/Remora.Discord.Gateway.Tests/Constants.cs
+++ b/Tests/Remora.Discord.Gateway.Tests/Constants.cs
@@ -51,4 +51,9 @@ public static class Constants
     /// Gets the default mocked session ID.
     /// </summary>
     public static string MockSessionID => "mock-session";
+
+    /// <summary>
+    /// Gets the default mocked resume gateway URL.
+    /// </summary>
+    public static string MockResumeGatewayUrl => "wss://resume-gateway.discord.gg/";
 }

--- a/Tests/Remora.Discord.Gateway.Tests/Tests/DiscordGatewayClientTests.cs
+++ b/Tests/Remora.Discord.Gateway.Tests/Tests/DiscordGatewayClientTests.cs
@@ -96,6 +96,7 @@ public class DiscordGatewayClientTests
                             Constants.BotUser,
                             new List<IUnavailableGuild>(),
                             "mock-session",
+                            Constants.MockResumeGatewayUrl,
                             default,
                             new PartialApplication()
                         )
@@ -156,6 +157,7 @@ public class DiscordGatewayClientTests
                             Constants.BotUser,
                             new List<IUnavailableGuild>(),
                             Constants.MockSessionID,
+                            Constants.MockResumeGatewayUrl,
                             default,
                             new PartialApplication()
                         )
@@ -229,6 +231,7 @@ public class DiscordGatewayClientTests
                             Constants.BotUser,
                             new List<IUnavailableGuild>(),
                             Constants.MockSessionID,
+                            Constants.MockResumeGatewayUrl,
                             default,
                             new PartialApplication()
                         )
@@ -262,6 +265,7 @@ public class DiscordGatewayClientTests
                             Constants.BotUser,
                             new List<IUnavailableGuild>(),
                             Constants.MockSessionID,
+                            Constants.MockResumeGatewayUrl,
                             default,
                             new PartialApplication()
                         )
@@ -337,6 +341,7 @@ public class DiscordGatewayClientTests
                             Constants.BotUser,
                             new List<IUnavailableGuild>(),
                             Constants.MockSessionID,
+                            Constants.MockResumeGatewayUrl,
                             default,
                             new PartialApplication()
                         )
@@ -412,6 +417,7 @@ public class DiscordGatewayClientTests
                             Constants.BotUser,
                             new List<IUnavailableGuild>(),
                             Constants.MockSessionID,
+                            Constants.MockResumeGatewayUrl,
                             default,
                             new PartialApplication()
                         )
@@ -472,6 +478,7 @@ public class DiscordGatewayClientTests
                             Constants.BotUser,
                             Array.Empty<IUnavailableGuild>(),
                             Constants.MockSessionID,
+                            Constants.MockResumeGatewayUrl,
                             default,
                             new PartialApplication()
                         )
@@ -495,6 +502,7 @@ public class DiscordGatewayClientTests
                             Constants.BotUser,
                             Array.Empty<IUnavailableGuild>(),
                             Constants.MockSessionID,
+                            Constants.MockResumeGatewayUrl,
                             default,
                             new PartialApplication()
                         )
@@ -518,6 +526,7 @@ public class DiscordGatewayClientTests
                             Constants.BotUser,
                             Array.Empty<IUnavailableGuild>(),
                             Constants.MockSessionID,
+                            Constants.MockResumeGatewayUrl,
                             default,
                             new PartialApplication()
                         )

--- a/Tests/Remora.Discord.Gateway.Tests/Tests/DiscordGatewayClientTests.cs
+++ b/Tests/Remora.Discord.Gateway.Tests/Tests/DiscordGatewayClientTests.cs
@@ -164,7 +164,7 @@ public class DiscordGatewayClientTests
                     )
                     .Send<Reconnect>()
                     .ExpectDisconnect()
-                    .ExpectConnection(new Uri($"wss://gateway.discord.gg/?v={(int)DiscordAPIVersion.V10}&encoding=json"))
+                    .ExpectConnection(new Uri($"{Constants.MockResumeGatewayUrl}?v={(int)DiscordAPIVersion.V10}&encoding=json"))
                     .Send(new Hello(TimeSpan.FromMilliseconds(200)))
                     .Expect<Resume>
                     (
@@ -238,7 +238,7 @@ public class DiscordGatewayClientTests
                     )
                     .Send<Reconnect>()
                     .ExpectDisconnect()
-                    .ExpectConnection(new Uri($"wss://gateway.discord.gg/?v={(int)DiscordAPIVersion.V10}&encoding=json"))
+                    .ExpectConnection(new Uri($"{Constants.MockResumeGatewayUrl}?v={(int)DiscordAPIVersion.V10}&encoding=json"))
                     .Send(new Hello(TimeSpan.FromMilliseconds(200)))
                     .Expect<Resume>
                     (

--- a/Tests/Remora.Discord.Tests/Samples/Gateway/Events/READY/READY.json
+++ b/Tests/Remora.Discord.Tests/Samples/Gateway/Events/READY/READY.json
@@ -14,6 +14,7 @@
       "avatar": null
     },
     "session_id": "none",
+    "resume_gateway_url": "wss://gateway.discord.gg/",
     "guilds": [],
     "application": {
       "id": "999999999999999999",


### PR DESCRIPTION
Implements support for the `resume_gateway_url`, sent with the `ready` payload to indicate which endpoint to connect to when resuming a gateway connection.

See: discord/discord-api-docs#5282