### PR TITLE
Parse channel and message urls with SnowflakeParser

### DIFF
--- a/Remora.Discord.Commands/Parsers/SnowflakeParser.cs
+++ b/Remora.Discord.Commands/Parsers/SnowflakeParser.cs
@@ -20,6 +20,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -38,9 +39,26 @@ namespace Remora.Discord.Commands.Parsers;
 [PublicAPI]
 public class SnowflakeParser : AbstractTypeParser<Snowflake>
 {
+    private static readonly Regex _channelLinkRegex = new
+    (
+        @"^https://(canary\.|ptb\.)?discord\.com/channels/(?<guild_id>@me|[0-9]*)/(?<channel_id>[0-9]*)(/(?<message_id>[0-9]*))?/?$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant
+    );
+
     /// <inheritdoc />
     public override ValueTask<Result<Snowflake>> TryParseAsync(string value, CancellationToken ct = default)
     {
+        var channelLinkMatch = _channelLinkRegex.Match(value);
+        if (channelLinkMatch.Success)
+        {
+            value = channelLinkMatch.Groups["message_id"].Value;
+
+            if (string.IsNullOrEmpty(value))
+            {
+                value = channelLinkMatch.Groups["channel_id"].Value;
+            }
+        }
+
         return new
         (
             !DiscordSnowflake.TryParse(value.Unmention(), out var snowflake)

--- a/Tests/Remora.Discord.Commands.Tests/Parsers/SnowflakeParserTests.cs
+++ b/Tests/Remora.Discord.Commands.Tests/Parsers/SnowflakeParserTests.cs
@@ -67,6 +67,24 @@ public class SnowflakeParserTests
     }
 
     /// <summary>
+    /// Tests whether the parser can parse snowflake value given by url.
+    /// </summary>
+    /// <param name="value">Mention that should be parsed correctly.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [InlineData("https://discord.com/channels/690919691404967977/765178263517397033")]
+    [InlineData("https://discord.com/channels/690919691404967977/1389600463250260019/765178263517397033")]
+    [InlineData("https://canary.discord.com/channels/690919691404967977/1389600463250260019/765178263517397033")]
+    [InlineData("https://ptb.discord.com/channels/690919691404967977/1389600463250260019/765178263517397033")]
+    [Theory]
+    public async Task CanParseSnowflakeByUrl(string value)
+    {
+        ulong snowflakeValue = 765178263517397033;
+        var tryParse = await _parser.TryParseAsync(value);
+        ResultAssert.Successful(tryParse);
+        Assert.Equal(snowflakeValue, tryParse.Entity.Value);
+    }
+
+    /// <summary>
     /// Tests whether the parser can parse snowflake value given by mentions.
     /// </summary>
     /// <param name="value">Mention that should be parsed correctly.</param>


### PR DESCRIPTION
Hey, a user of my bot tried to use a link in a command. It wasn't working and it causes bit of a confusion as the mention looks the same a sent link in the client. I will use this in my bot if it won't be accepted here for sure, but wanted to check with you here for feedback / to merge this to Remora.Discord directly if others will appreciate this behavior as well. I can add more validation if needed, ie. to check if there are only 2 or 3 parts after the url (guild, channel, message), and to check if they consist of all numbers if you think that is necessary. But I don't see any risks if wrong links, such as https://discord.com/channels/XYZ/XYZ/XYZ/XYZ/<snowflakeid here> are accepted.

If user sends a link to a channel, it's not being parsed by Remora. On the other hand the client understands this link and visually there is no difference between a mention and a channel link.

Add parsing of a channel links, without checking the whole string, only beginning 'https://discord.com/channels/' is used to check this is a url, and only the last part of the string is then used, all other parts are ignored.