### PR TITLE
Fixes #363 Bump Humanizer to 3.x

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
-    <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
+    <PackageVersion Include="Humanizer.Core" Version="3.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.5" />

--- a/Remora.Discord.Extensions/Embeds/EmbedBuilder.cs
+++ b/Remora.Discord.Extensions/Embeds/EmbedBuilder.cs
@@ -105,7 +105,7 @@ public class EmbedBuilder : BuilderBase<Embed>
         {
             var titleLength = this.Title?.Length ?? 0;
             var descriptionLength = this.Description?.Length ?? 0;
-            var fieldSum = _fields.Sum(field => field.Name.Length + field.Value.Length);
+            var fieldSum = _fields.Sum(x => x.Name.Length + x.Value.Length);
             var footerLength = this.Footer?.Text.Length ?? 0;
             var authorLength = this.Author?.Name.Length ?? 0;
 


### PR DESCRIPTION
Humanizer has gone from 2.x to 3.x

Migration guide available here: https://github.com/Humanizr/Humanizer/blob/main/docs/migration-v3.md

Additional issue: https://github.com/Humanizr/Humanizer/issues/1656

No breaking changes seem to affect Remora.Discord here.

Motivation is for me to be able to use latest Humanizer in downstream.

An additional change for `EmbedBuilder` was added, unrelated to the Humanizer issue. This allows for .NET 10 SDK to compile, as `field` is now a keyword.