### PR TITLE
fix(EmbedBuilder): escape field keyword

### DIFF
--- a/Remora.Discord.Extensions/Embeds/EmbedBuilder.cs
+++ b/Remora.Discord.Extensions/Embeds/EmbedBuilder.cs
@@ -105,7 +105,7 @@ public class EmbedBuilder : BuilderBase<Embed>
         {
             var titleLength = this.Title?.Length ?? 0;
             var descriptionLength = this.Description?.Length ?? 0;
-            var fieldSum = _fields.Sum(field => field.Name.Length + field.Value.Length);
+            var fieldSum = _fields.Sum(@field => @field.Name.Length + @field.Value.Length);
             var footerLength = this.Footer?.Text.Length ?? 0;
             var authorLength = this.Author?.Name.Length ?? 0;
 


### PR DESCRIPTION
Starting from C# 14, `field` is a keyword in properties and must be escaped with the verbatim prefix